### PR TITLE
[Feat/#13] 마켓인증 관련 이미지 데이터 GET 기능 구현 & "영업의 종류" 필드 추가

### DIFF
--- a/MatQ_Admin/App/DI/DataAssembly.swift
+++ b/MatQ_Admin/App/DI/DataAssembly.swift
@@ -55,7 +55,8 @@ final class DataAssembly: Assembly {
         container.register(MarketAuthRepositoryInterface.self, factory: { (
             resolver: Resolver
         ) -> MarketAuthRepository in
-            return .init(marketAuthService: resolver.resolve(MarketAuthServiceInterface.self)!)
+            return .init(marketAuthService: resolver.resolve(MarketAuthServiceInterface.self)!,
+                         imageService: resolver.resolve(ImageServiceInterface.self)!)
         }).inObjectScope(.container)
 
         

--- a/MatQ_Admin/Data/Network/API/DTO/GetMarket.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/GetMarket.swift
@@ -43,7 +43,7 @@ struct GetMarketDetailResponse: Decodable {
 
 extension GetMarketDetailResponse {
     var toDomain: MarketDetail {
-        return MarketDetail(marketId: data.marketId, logoImage: data.logoImageId, name: data.name, district: data.district, phone: data.phone, address: data.address, status: data.status, marketTime: data.marketTimes)
+        return MarketDetail(marketId: data.marketId, logoImageId: data.logoImageId, logoImage: nil, name: data.name, district: data.district, phone: data.phone, address: data.address, status: data.status, marketTime: data.marketTimes)
     }
 }
 

--- a/MatQ_Admin/Data/Network/API/DTO/GetMarketAuth.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/GetMarketAuth.swift
@@ -25,7 +25,7 @@ struct GetMarketAuthResponse: Decodable {
 
 extension GetMarketAuthResponse {
     var toDomain: [MarketAuth] {
-        return self.data.map { MarketAuth(recordId: $0.recordId, marketId: $0.marketId, operator: $0.operator, license: $0.license) }
+        return self.data.map { MarketAuth(recordId: $0.recordId, marketId: $0.marketId, operator: Operator(awsOperator: $0.operator), license: License(awsLicense: $0.license)) }
     }
 }
 
@@ -58,14 +58,14 @@ struct PutReviewMarketAuthResponse: Decodable {
 
 
 // MARK: - GetMarketAuth
-struct GetMarketAuth : Codable {
+struct GetMarketAuth: Codable {
     let recordId, marketId: String
     let reviewResult : String?
     let comment: String?
-    let `operator`: Operator
-    let license: License
+    let `operator`: AwsOperator
+    let license: AwsLicense
     
-    init(recordId: String, marketId: String, reviewResult: String, comment: String?, operator: Operator, license: License) {
+    init(recordId: String, marketId: String, reviewResult: String, comment: String?, operator: AwsOperator, license: AwsLicense) {
         self.recordId = recordId
         self.marketId = marketId
         self.reviewResult = reviewResult
@@ -75,21 +75,22 @@ struct GetMarketAuth : Codable {
     }
 }
 
-// MARK: - Operator
-struct Operator : Codable, Equatable {
+// MARK: - AwsOperator
+
+struct AwsOperator: Codable, Equatable {
     let name : String
     let birthdate: String
     let idcardImage: AwsImage
 }
 
 // MARK: - AwsImage
-struct AwsImage : Codable, Equatable {
+struct AwsImage: Codable, Equatable {
     let imageId, location: String
 }
 
-// MARK: - License
-struct License : Codable, Equatable {
+// MARK: - AwsLicense
+struct AwsLicense: Codable, Equatable {
     let licenseId: String
     let licenseImage: AwsImage
-    let ownerName, marketName, address, postalCode: String
+    let ownerName, marketName, address, postalCode: String, salesType: String? // TODO: 배포 시 옵셔널 해제
 }

--- a/MatQ_Admin/Data/Repository/MarketRepository.swift
+++ b/MatQ_Admin/Data/Repository/MarketRepository.swift
@@ -77,8 +77,9 @@ final class MarketRepository: MarketRepositoryInterface {
     func getMarketDetail(marketId: String) async throws -> MarketDetail {
         let result = await self.marketService.fetchMarketDetail(request: GetMarketDetailRequest(marketId: marketId))
         switch result {
-        case .success(let movies):
-            return movies
+        case .success(var data):
+            data.logoImage = await loadImage(imageId: data.logoImageId)
+            return data
         case .failure:
             throw NetworkError.serverError
         }

--- a/MatQ_Admin/Domain/Entity/Market.swift
+++ b/MatQ_Admin/Domain/Entity/Market.swift
@@ -20,7 +20,8 @@ struct Market {
 /// 인증 들어갈 때 사용
 struct MarketDetail: Equatable {
     let marketId: String
-    let logoImage: String
+    let logoImageId: String
+    var logoImage: UIImage?
     let name: String
     let district: String
     let phone: String

--- a/MatQ_Admin/Domain/Entity/MarketAuthReview.swift
+++ b/MatQ_Admin/Domain/Entity/MarketAuthReview.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 struct MarketAuthRiview {
     let marketId: String
@@ -16,6 +17,57 @@ struct MarketAuthRiview {
 // TODO: 확인
 struct MarketAuth: Equatable {
     let recordId, marketId: String
-    let `operator`: Operator
-    let license: License
+    var `operator`: Operator
+    var license: License
+}
+
+struct Operator: Equatable {
+    let name : String
+    let birthdate: String
+    let idcardImage: AwsImage
+    var idcardUIImage: UIImage?
+    
+    init(name: String, birthdate: String, idcardImage: AwsImage, idcardUIImage: UIImage? = nil) {
+        self.name = name
+        self.birthdate = birthdate
+        self.idcardImage = idcardImage
+        self.idcardUIImage = idcardUIImage
+    }
+    
+    init(awsOperator: AwsOperator) {
+        self.name = awsOperator.name
+        self.birthdate = awsOperator.birthdate
+        self.idcardImage = awsOperator.idcardImage
+        self.idcardUIImage = nil
+    }
+}
+
+struct License: Equatable {
+    let licenseId: String
+    let licenseImage: AwsImage
+    let ownerName, marketName, address, postalCode: String
+    let salesType: String? // TODO: 배포 시 옵셔널 해제
+    var image: UIImage?
+    
+    init(licenseId: String, licenseImage: AwsImage, ownerName: String, marketName: String, address: String, postalCode: String, salesType: String?, image: UIImage? = nil) {
+        self.licenseId = licenseId
+        self.licenseImage = licenseImage
+        self.ownerName = ownerName
+        self.marketName = marketName
+        self.address = address
+        self.postalCode = postalCode
+        self.salesType = salesType
+        self.image = image
+    }
+    
+    init(awsLicense: AwsLicense) {
+        self.licenseId = awsLicense.licenseId
+        self.licenseImage = awsLicense.licenseImage
+        self.ownerName = awsLicense.ownerName
+        self.marketName = awsLicense.marketName
+        self.address = awsLicense.address
+        self.postalCode = awsLicense.postalCode
+        self.salesType = awsLicense.salesType
+        self.image = nil
+    }
 }

--- a/MatQ_Admin/Presentation/Component/InfoComponent.swift
+++ b/MatQ_Admin/Presentation/Component/InfoComponent.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct InfoComponent: View {
     let titleName : String
     var contentName : String?
-    var imageName: String?
+    var uiImage: UIImage?
     
     var body: some View {
         VStack(alignment: .leading){
@@ -27,14 +27,15 @@ struct InfoComponent: View {
                             .foregroundStyle(.componentPrimary)
                     )
             }
-            // TODO: 이미지 연결
-//            if image = imageName {
-//               AsyncImage(url: imageName)
-//                    .frame(maxWidth: .infinity, alignment: .leading)
-//                    .font(.body)
-//                    .padding()
-//                    .background(.regularMaterial)
-//            }
+            
+            if let image = uiImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .frame(width:98, height:98)
+                    .cornerRadius(12)
+                    .frame(maxWidth: .infinity)
+                    .background(.regularMaterial)
+            }
             
         }
         .padding(.bottom, 16)

--- a/MatQ_Admin/Presentation/Component/InfoComponent.swift
+++ b/MatQ_Admin/Presentation/Component/InfoComponent.swift
@@ -22,7 +22,10 @@ struct InfoComponent: View {
                     .font(.body)
                     .foregroundStyle(.textPrimary)
                     .padding()
-                    .background(.bgComponent)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(.componentPrimary)
+                    )
             }
             // TODO: 이미지 연결
 //            if image = imageName {

--- a/MatQ_Admin/Presentation/Component/MarketComponent.swift
+++ b/MatQ_Admin/Presentation/Component/MarketComponent.swift
@@ -35,7 +35,7 @@ struct MarketComponent: View {
         .frame(height: 108)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .foregroundStyle(.bgComponent)
+                .foregroundStyle(.componentSecondary)
         )
         .shadow(color: .black.opacity(0.05), radius: 12)
         .padding(.horizontal, 20)

--- a/MatQ_Admin/Presentation/Component/NoticeComponent.swift
+++ b/MatQ_Admin/Presentation/Component/NoticeComponent.swift
@@ -34,7 +34,7 @@ struct NoticeComponent: View {
         .frame(maxWidth: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .foregroundStyle(.bgComponent)
+                .foregroundStyle(.componentPrimary)
         )
         .frame(height: 80)
     }

--- a/MatQ_Admin/Presentation/View/Market/MarketAuthReview/MarketAuthReviewView.swift
+++ b/MatQ_Admin/Presentation/View/Market/MarketAuthReview/MarketAuthReviewView.swift
@@ -96,7 +96,7 @@ struct MarketAuthReviewView: View {
                 .font(.body)
                 .background(
                     RoundedRectangle(cornerRadius: 16)
-                        .foregroundStyle(.bgComponent)
+                        .foregroundStyle(.componentPrimary)
                 )
                 .tint(.tintYellow)
         }

--- a/MatQ_Admin/Presentation/View/Market/MarketAuthReview/MarketAuthReviewViewModel.swift
+++ b/MatQ_Admin/Presentation/View/Market/MarketAuthReview/MarketAuthReviewViewModel.swift
@@ -26,7 +26,7 @@ final class MarketAuthReviewViewModel: MarketAuthReviewViewModelInput, MarketAut
     let marketId: String
     
     // MARK: Output
-    var items: MarketAuthReviewItemViewModel = MarketAuthReviewItemViewModel(marketId: "", name: "", marketAuth: .init(recordId: "", marketId: "", operator: .init(name: "", birthdate: "", idcardImage: .init(imageId: "", location: "")), license: .init(licenseId: "", licenseImage: .init(imageId: "", location: ""), ownerName: "", marketName: "", address: "", postalCode: "")), marketDetail: .init(marketId: "", logoImage: "", name: "", district: "", phone: "", address: "", status: "", marketTime: []))
+    var items: MarketAuthReviewItemViewModel = MarketAuthReviewItemViewModel(marketId: "", name: "", marketAuth: .init(recordId: "", marketId: "", operator: .init(name: "", birthdate: "", idcardImage: .init(imageId: "", location: "")), license: .init(licenseId: "", licenseImage: .init(imageId: "", location: ""), ownerName: "", marketName: "", address: "", postalCode: "", salesType: "")), marketDetail: .init(marketId: "", logoImageId: "", logoImage: nil, name: "", district: "", phone: "", address: "", status: "", marketTime: []))
     
     @Published var comment: String = ""
     @Published var feedbackMessage: String = ""
@@ -64,9 +64,8 @@ final class MarketAuthReviewViewModel: MarketAuthReviewViewModelInput, MarketAut
                 return
             }
             
-            let authItemViewModel = MarketAuthReviewItemViewModel(marketId: marketId, name: detailResult.name, marketAuth: authResult, marketDetail: detailResult)
-            
-            self.items = authItemViewModel
+            self.items = MarketAuthReviewItemViewModel(marketId: marketId, name: detailResult.name, marketAuth: authResult, marketDetail: detailResult)
+
         } catch {
             self.error.send("Fail to load market")
         }

--- a/MatQ_Admin/Presentation/View/Market/MarketAuthReview/SubView/BusinessRegistrationView.swift
+++ b/MatQ_Admin/Presentation/View/Market/MarketAuthReview/SubView/BusinessRegistrationView.swift
@@ -21,12 +21,12 @@ struct BusinessRegistrationView: View {
                     .font(.title3.bold())
 
                 InfoComponent(titleName: "영업신고증 고유번호", contentName: license.licenseId)
-                InfoComponent(titleName: "영업의 종류", contentName: license.licenseId) // TODO: 백 수정시 변경
+                InfoComponent(titleName: "영업의 종류", contentName: license.salesType)
                 InfoComponent(titleName: "대표자", contentName: license.ownerName)
                 InfoComponent(titleName: "영업소 명칭 (상호명)", contentName: license.marketName)
                 InfoComponent(titleName: "소재지", contentName: license.address)
                 InfoComponent(titleName: "우편번호", contentName: license.postalCode)
-                InfoComponent(titleName: "영업신고증 이미지", imageName: license.licenseImage.imageId)
+                InfoComponent(titleName: "영업신고증 이미지", uiImage: license.image)
 
             }
             .padding(.horizontal)

--- a/MatQ_Admin/Presentation/View/Market/MarketAuthReview/SubView/IdentificationView.swift
+++ b/MatQ_Admin/Presentation/View/Market/MarketAuthReview/SubView/IdentificationView.swift
@@ -15,14 +15,14 @@ struct IdentificationView: View {
     var body: some View {
         NavigationBarComponent(navigationTitle: "신분증", isNotRoot: true)
         
-        ScrollView{
+        ScrollView(.vertical){
             VStack(alignment: .leading){
                 Text("신분증")
                     .font(.title3.bold())
 
                 InfoComponent(titleName: "성함", contentName: operatorData.name)
                 InfoComponent(titleName: "생년월일", contentName: operatorData.birthdate)
-                InfoComponent(titleName: "신분증 이미지", imageName: operatorData.idcardImage.imageId)
+                InfoComponent(titleName: "신분증 이미지", uiImage: operatorData.idcardUIImage)
                 Text("주민등록번호 뒤 7자리가 기재된 공간 마스킹 필요\n주민등록번호 뒷자리를 지우지 않은 신분증은 즉시 파기되며 요청 반려")
                     .font(.footnote)
             }

--- a/MatQ_Admin/Presentation/View/Market/MarketAuthReview/SubView/MarketDetailInfoView.swift
+++ b/MatQ_Admin/Presentation/View/Market/MarketAuthReview/SubView/MarketDetailInfoView.swift
@@ -19,11 +19,12 @@ struct MarketDetailInfoView: View {
                     .font(.title3.bold())
                 
                 HStack(alignment: .center) {
-                    // TODO: 이미지 연결
-                    Image(marketDetail.logoImage)
-                        .resizable()
-                        .frame(width:98, height:98)
-                        .cornerRadius(20)
+                    if let image =  marketDetail.logoImage {
+                        Image(uiImage: image)
+                            .resizable()
+                            .frame(width:98, height:98)
+                            .cornerRadius(20)
+                    }
                 }
                 .frame(maxWidth: .infinity)
                 
@@ -97,5 +98,5 @@ enum 요일: CaseIterable {
 }
 
 #Preview {
-    MarketDetailInfoView(marketDetail: .init(marketId: "id000", logoImage: "", name: "MARKET", district: "111110000", phone: "010-3030-3030", address: "서울틀별시", status: "", marketTime: [.init(weekDay: "월", openTime: "08:00", closeTime: "21:00", holidayYn: "N")]))
+    MarketDetailInfoView(marketDetail: .init(marketId: "id000", logoImageId: "", logoImage: nil, name: "MARKET", district: "111110000", phone: "010-3030-3030", address: "서울틀별시", status: "", marketTime: [.init(weekDay: "월", openTime: "08:00", closeTime: "21:00", holidayYn: "N")]))
 }

--- a/MatQ_Admin/Presentation/View/Market/MarketMain/MarketMainView.swift
+++ b/MatQ_Admin/Presentation/View/Market/MarketMain/MarketMainView.swift
@@ -34,7 +34,7 @@ struct MarketMainView: View {
         .alert(isPresented: $vm.showingAlert) {
             Alert(title: Text("Error"), message: Text(vm.errorMessage), dismissButton: .default(Text("OK")))
         }
-        .background(Color.gray.opacity(0.05))
+        .background(.bgSecondary)
     }
     
     private var marketListView: some View {

--- a/MatQ_Admin/Resources/Assets.xcassets/bgSecondary.colorset/Contents.json
+++ b/MatQ_Admin/Resources/Assets.xcassets/bgSecondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x10",
+          "green" : "0x10",
+          "red" : "0x10"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MatQ_Admin/Resources/Assets.xcassets/componentPrimary.colorset/Contents.json
+++ b/MatQ_Admin/Resources/Assets.xcassets/componentPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF6",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x19",
+          "green" : "0x16",
+          "red" : "0x14"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MatQ_Admin/Resources/Assets.xcassets/componentSecondary.colorset/Contents.json
+++ b/MatQ_Admin/Resources/Assets.xcassets/componentSecondary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "blue" : "0xFD",
+          "green" : "0xFD",
+          "red" : "0xFD"
         }
       },
       "idiom" : "universal"
@@ -23,7 +23,7 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x14",
+          "blue" : "0x19",
           "green" : "0x16",
           "red" : "0x14"
         }


### PR DESCRIPTION
- [x] 마켓인증 데이터 중 **신분증, 영업신고증, 마켓로고 이미지 연결**
- [x] 디자인 수정 (다크모드 대응 색상 분리 및 적용)
- [x] "영업의 종류" 필드 추가