### PR TITLE
[Feat/#39] 퀘스트 삭제 버튼 클릭한 경우 "삭제/취소 Alert" 추가 구현

### DIFF
--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
@@ -19,14 +19,18 @@ struct QuestDetailView: View {
                 .overlay(alignment: .trailing) {
                     HStack(spacing: 20) {
                         Button {
-                            vm.deleteData(questId: vm.editedItems.questId, type: .soft)
+                            vm.showAlert = true
+                            vm.selectedDeleteType = .soft
+                            vm.activeAlertType = .delete
                         } label: {
                             Image(systemName: "eraser")
                                 .foregroundStyle(.primaryPurple)
                         }
                         
                         Button {
-                            vm.deleteData(questId: vm.editedItems.questId, type: .hard)
+                            vm.showAlert = true
+                            vm.selectedDeleteType = .hard
+                            vm.activeAlertType = .delete
                         } label: {
                             Image(systemName: "trash")
                                 .foregroundStyle(.primaryPurple)
@@ -65,15 +69,29 @@ struct QuestDetailView: View {
             }
         }
         .alert(isPresented: $vm.showAlert) {
-            Alert(
-                title: Text(vm.alertTitle),
-                message: Text(vm.alertMessage),
-                dismissButton: .default(Text("확인")) {
-                    if vm.alertTitle == "퀘스트 추가 성공" || vm.alertTitle == "퀘스트 삭제 성공" {
-                        router.pop()
+            switch vm.activeAlertType {
+            case .delete:
+                Alert(
+                    title: Text("퀘스트를 삭제하시겠습니까?"),
+                    message: Text("퀘스트를 복구할 수 없습니다."),
+                    primaryButton: .cancel(Text("취소")),
+                    secondaryButton: .destructive(Text("삭제")) {
+                        vm.deleteData(questId: vm.editedItems.questId, type: vm.selectedDeleteType)
                     }
-                }
-            )
+                )
+            case .result:
+                Alert(
+                    title: Text(vm.alertTitle),
+                    message: Text(vm.alertMessage),
+                    dismissButton: .default(Text("확인")) {
+                        if vm.alertTitle == "퀘스트 추가 성공" || vm.alertTitle == "퀘스트 삭제 성공" {
+                            router.pop()
+                        }
+                    }
+                )
+            case .none:
+                Alert(title: Text(""))
+            }
         }
     }
 }

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
@@ -39,9 +39,26 @@ final class QuestDetailViewModel: ObservableObject {
     let items: QuestDetailViewModelItem
     @Published var editedItems: QuestDetailViewModelItem
     
-    @Published var showAlert: Bool = false
+    // 퀘스트 추가&삭제 Alert 관련
     @Published var alertTitle: String = ""
     @Published var alertMessage: String = ""
+    @Published var showAlert: Bool = false
+    @Published var activeAlertType: ActiveAlertType?
+    @Published var selectedDeleteType: QuestDeleteType = .hard
+    
+    enum ActiveAlertType: Identifiable {
+        case delete
+        case result
+        
+        var id: Int {
+            switch self {
+            case .delete:
+                return 1
+            case .result:
+                return 2
+            }
+        }
+    }
     
     var subscriptions = Set<AnyCancellable>()
     
@@ -73,11 +90,13 @@ final class QuestDetailViewModel: ObservableObject {
                 if case .failure(let error) = completion {
                     self?.alertTitle = "퀘스트 추가 실패"
                     self?.alertMessage = error.localizedDescription
+                    self?.activeAlertType = .result
                     self?.showAlert = true
                 }
             } receiveValue: { [weak self] _ in
                 self?.alertTitle = "퀘스트 추가 성공"
                 self?.alertMessage = "퀘스트가 성공적으로 추가되었습니다"
+                self?.activeAlertType = .result
                 self?.showAlert = true
             }
             .store(in: &subscriptions)
@@ -89,11 +108,13 @@ final class QuestDetailViewModel: ObservableObject {
                 if case .failure(let error) = completion {
                     self?.alertTitle = "퀘스트 삭제 실패"
                     self?.alertMessage = error.localizedDescription
+                    self?.activeAlertType = .result
                     self?.showAlert = true
                 }
             } receiveValue: { [weak self] _ in
                 self?.alertTitle = "퀘스트 삭제 성공"
                 self?.alertMessage = "퀘스트가 성공적으로 삭제되었습니다"
+                self?.activeAlertType = .result
                 self?.showAlert = true
             }
             .store(in: &subscriptions)


### PR DESCRIPTION
close #39

한 뷰에 alert가 여러 개인 경우 구현 방법
**1. enum으로 관리하도록 구현**
2. @State / @Published 로 변수 여러개로 구현하는 방법 _(<--------------왜 published의 p는 대문자가 안될까요..)_

1번 방식으로 구현한 이유
- 다른 방법도 있지만, 2개 이상일 경우 변수를 관리하기 쉽다고 생각(지금도 더욱 개선하고 싶은 부분이 보임-ㅠ..)
- 2번방식인 경우 .alert 모디파이어를 다는 부분이 모두 뷰의 최하위에 위치해야함. 하나라도 부모뷰이면 모든 alert이 표시되지 않음.