### PR TITLE
[Feat/#45] 신고된 챌린지 관리 기능 구현(조회, 삭제, 상태 수정)  &  레이어간 반환값 수정

### DIFF
--- a/MatQ_Admin.xcodeproj/project.pbxproj
+++ b/MatQ_Admin.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		60004FF02C662365009AECF2 /* ImageDataTransferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60004FEF2C662365009AECF2 /* ImageDataTransferable.swift */; };
 		60004FF22C662495009AECF2 /* NetworkConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60004FF12C662495009AECF2 /* NetworkConfiguration.swift */; };
 		601048712C652FC20028662D /* UIImage++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601048702C652FC20028662D /* UIImage++.swift */; };
+		606329932C7483E8000F4513 /* PatchChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */; };
+		606329952C748E10000F4513 /* DeleteChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */; };
 		608EBF8A2C38709800B862CC /* AppInject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF892C38709800B862CC /* AppInject.swift */; };
 		608EBF8D2C38716100B862CC /* QuestMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF8C2C38716100B862CC /* QuestMainView.swift */; };
 		608EBF8F2C38716900B862CC /* QuestDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF8E2C38716900B862CC /* QuestDetailView.swift */; };
@@ -31,6 +33,13 @@
 		60DB54BF2C73876600AEDFE9 /* ManageListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54BE2C73876600AEDFE9 /* ManageListItemView.swift */; };
 		60DB54C12C7393DB00AEDFE9 /* ManageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54C02C7393DB00AEDFE9 /* ManageDetailView.swift */; };
 		60DB54C32C73940100AEDFE9 /* ManageDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54C22C73940100AEDFE9 /* ManageDetailViewModel.swift */; };
+		60DB54C52C73BBD600AEDFE9 /* ChallengeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54C42C73BBD600AEDFE9 /* ChallengeDataSource.swift */; };
+		60DB54C72C73BC4D00AEDFE9 /* ChallengeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54C62C73BC4D00AEDFE9 /* ChallengeModel.swift */; };
+		60DB54C92C73BD4F00AEDFE9 /* Challenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54C82C73BD4F00AEDFE9 /* Challenge.swift */; };
+		60DB54CB2C73BF5500AEDFE9 /* ChallengeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54CA2C73BF5500AEDFE9 /* ChallengeTarget.swift */; };
+		60DB54CD2C73C12600AEDFE9 /* ChallengeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54CC2C73C12600AEDFE9 /* ChallengeRepository.swift */; };
+		60DB54CF2C73C15200AEDFE9 /* ChallengeRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54CE2C73C15200AEDFE9 /* ChallengeRepositoryInterface.swift */; };
+		60DB54D12C73C1F900AEDFE9 /* GetChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DB54D02C73C1F900AEDFE9 /* GetChallengeUseCase.swift */; };
 		60E696A32B97BDC9009DD235 /* ViewAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E696A22B97BDC9009DD235 /* ViewAssembly.swift */; };
 		60E696A72B97BE08009DD235 /* ViewModelAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E696A62B97BE08009DD235 /* ViewModelAssembly.swift */; };
 		60E696A92B97BEAE009DD235 /* DependencyInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E696A82B97BEAE009DD235 /* DependencyInjector.swift */; };
@@ -81,6 +90,8 @@
 		60004FEF2C662365009AECF2 /* ImageDataTransferable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataTransferable.swift; sourceTree = "<group>"; };
 		60004FF12C662495009AECF2 /* NetworkConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConfiguration.swift; sourceTree = "<group>"; };
 		601048702C652FC20028662D /* UIImage++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage++.swift"; sourceTree = "<group>"; };
+		606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchChallengeUseCase.swift; sourceTree = "<group>"; };
+		606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteChallengeUseCase.swift; sourceTree = "<group>"; };
 		608EBF892C38709800B862CC /* AppInject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInject.swift; sourceTree = "<group>"; };
 		608EBF8C2C38716100B862CC /* QuestMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMainView.swift; sourceTree = "<group>"; };
 		608EBF8E2C38716900B862CC /* QuestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestDetailView.swift; sourceTree = "<group>"; };
@@ -102,6 +113,13 @@
 		60DB54BE2C73876600AEDFE9 /* ManageListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageListItemView.swift; sourceTree = "<group>"; };
 		60DB54C02C7393DB00AEDFE9 /* ManageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDetailView.swift; sourceTree = "<group>"; };
 		60DB54C22C73940100AEDFE9 /* ManageDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDetailViewModel.swift; sourceTree = "<group>"; };
+		60DB54C42C73BBD600AEDFE9 /* ChallengeDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDataSource.swift; sourceTree = "<group>"; };
+		60DB54C62C73BC4D00AEDFE9 /* ChallengeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeModel.swift; sourceTree = "<group>"; };
+		60DB54C82C73BD4F00AEDFE9 /* Challenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Challenge.swift; sourceTree = "<group>"; };
+		60DB54CA2C73BF5500AEDFE9 /* ChallengeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeTarget.swift; sourceTree = "<group>"; };
+		60DB54CC2C73C12600AEDFE9 /* ChallengeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeRepository.swift; sourceTree = "<group>"; };
+		60DB54CE2C73C15200AEDFE9 /* ChallengeRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeRepositoryInterface.swift; sourceTree = "<group>"; };
+		60DB54D02C73C1F900AEDFE9 /* GetChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChallengeUseCase.swift; sourceTree = "<group>"; };
 		60E696A22B97BDC9009DD235 /* ViewAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewAssembly.swift; sourceTree = "<group>"; };
 		60E696A62B97BE08009DD235 /* ViewModelAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelAssembly.swift; sourceTree = "<group>"; };
 		60E696A82B97BEAE009DD235 /* DependencyInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyInjector.swift; sourceTree = "<group>"; };
@@ -212,6 +230,7 @@
 			isa = PBXGroup;
 			children = (
 				60F27DF82C46039400711A53 /* QuestRepository.swift */,
+				60DB54CC2C73C12600AEDFE9 /* ChallengeRepository.swift */,
 				60DB54B72C73788900AEDFE9 /* ImageRepository.swift */,
 			);
 			path = Repository;
@@ -231,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				608EBF922C3872D700B862CC /* Quest.swift */,
+				60DB54C82C73BD4F00AEDFE9 /* Challenge.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -241,6 +261,9 @@
 				60F27DF42C4602DD00711A53 /* GetQuestUseCase.swift */,
 				60F27DFA2C4616D500711A53 /* PostQuestUseCase.swift */,
 				60F27DFC2C461B2B00711A53 /* DeleteQuestUseCase.swift */,
+				60DB54D02C73C1F900AEDFE9 /* GetChallengeUseCase.swift */,
+				606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */,
+				606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -258,6 +281,7 @@
 			isa = PBXGroup;
 			children = (
 				60F27DF22C45FD0E00711A53 /* QuestDataSource.swift */,
+				60DB54C42C73BBD600AEDFE9 /* ChallengeDataSource.swift */,
 				60E696BE2B9A1FC1009DD235 /* ImageDataSource.swift */,
 			);
 			path = DataSource;
@@ -289,6 +313,7 @@
 			isa = PBXGroup;
 			children = (
 				60F27DEC2C45691F00711A53 /* QuestModel.swift */,
+				60DB54C62C73BC4D00AEDFE9 /* ChallengeModel.swift */,
 				60E696BA2B9A1BFE009DD235 /* ImageModel.swift */,
 			);
 			path = DTO;
@@ -310,6 +335,7 @@
 			isa = PBXGroup;
 			children = (
 				60F27DF62C46031A00711A53 /* QuestRepositoryInterface.swift */,
+				60DB54CE2C73C15200AEDFE9 /* ChallengeRepositoryInterface.swift */,
 				60DB54B42C73763F00AEDFE9 /* ImageRepositoryInterface.swift */,
 			);
 			path = RepositoryInterface;
@@ -333,6 +359,7 @@
 			children = (
 				60E696BC2B9A1ED4009DD235 /* ImageTarget.swift */,
 				60F27DF02C45FADC00711A53 /* QuestTarget.swift */,
+				60DB54CA2C73BF5500AEDFE9 /* ChallengeTarget.swift */,
 			);
 			path = Target;
 			sourceTree = "<group>";
@@ -516,9 +543,11 @@
 				60F27DF32C45FD0E00711A53 /* QuestDataSource.swift in Sources */,
 				E5DD82742B3509A700A026C2 /* PopupComponent.swift in Sources */,
 				608EBF8F2C38716900B862CC /* QuestDetailView.swift in Sources */,
+				606329932C7483E8000F4513 /* PatchChallengeUseCase.swift in Sources */,
 				60DB54C12C7393DB00AEDFE9 /* ManageDetailView.swift in Sources */,
 				60E696B12B98958C009DD235 /* ButtonLabelComponent.swift in Sources */,
 				60F27DF12C45FADC00711A53 /* QuestTarget.swift in Sources */,
+				60DB54C72C73BC4D00AEDFE9 /* ChallengeModel.swift in Sources */,
 				E5DD827B2B350A9E00A026C2 /* NavigationStackRouter.swift in Sources */,
 				60F27DFD2C461B2B00711A53 /* DeleteQuestUseCase.swift in Sources */,
 				608EBF972C390C5200B862CC /* QuestDetailViewModel.swift in Sources */,
@@ -527,6 +556,7 @@
 				608EBF932C3872D700B862CC /* Quest.swift in Sources */,
 				60DA570C2B94124F00EDAF30 /* NetworkError.swift in Sources */,
 				60F27DED2C45691F00711A53 /* QuestModel.swift in Sources */,
+				60DB54CD2C73C12600AEDFE9 /* ChallengeRepository.swift in Sources */,
 				608EBF8D2C38716100B862CC /* QuestMainView.swift in Sources */,
 				60DB54B12C7272E400AEDFE9 /* NetworkService.swift in Sources */,
 				60F27DFB2C4616D500711A53 /* PostQuestUseCase.swift in Sources */,
@@ -535,13 +565,16 @@
 				60004FF22C662495009AECF2 /* NetworkConfiguration.swift in Sources */,
 				60EC52002B9D99CE002CBCA3 /* View++.swift in Sources */,
 				60E696A72B97BE08009DD235 /* ViewModelAssembly.swift in Sources */,
+				60DB54D12C73C1F900AEDFE9 /* GetChallengeUseCase.swift in Sources */,
 				60DA570E2B94132E00EDAF30 /* Endpoint.swift in Sources */,
+				606329952C748E10000F4513 /* DeleteChallengeUseCase.swift in Sources */,
 				60E696A92B97BEAE009DD235 /* DependencyInjector.swift in Sources */,
 				60DA57132B94152000EDAF30 /* HttpHeaderField.swift in Sources */,
 				60DA57102B94147C00EDAF30 /* TargetType.swift in Sources */,
 				60DB54B52C73763F00AEDFE9 /* ImageRepositoryInterface.swift in Sources */,
 				60E696B52B98C583009DD235 /* Bundle++.swift in Sources */,
 				60E696A32B97BDC9009DD235 /* ViewAssembly.swift in Sources */,
+				60DB54C92C73BD4F00AEDFE9 /* Challenge.swift in Sources */,
 				60F27DEF2C45F1A900711A53 /* CommonResponse.swift in Sources */,
 				601048712C652FC20028662D /* UIImage++.swift in Sources */,
 				60F27DF72C46031A00711A53 /* QuestRepositoryInterface.swift in Sources */,
@@ -553,12 +586,15 @@
 				60E696BF2B9A1FC1009DD235 /* ImageDataSource.swift in Sources */,
 				608EBF992C39166F00B862CC /* TextFieldComponent.swift in Sources */,
 				60F27DF52C4602DD00711A53 /* GetQuestUseCase.swift in Sources */,
+				60DB54C52C73BBD600AEDFE9 /* ChallengeDataSource.swift in Sources */,
+				60DB54CF2C73C15200AEDFE9 /* ChallengeRepositoryInterface.swift in Sources */,
 				608EBF8A2C38709800B862CC /* AppInject.swift in Sources */,
 				E5DD82762B3509F600A026C2 /* InfoComponent.swift in Sources */,
 				E5DD825A2B34DCCA00A026C2 /* MatQ_AdminApp.swift in Sources */,
 				60DB54B82C73788900AEDFE9 /* ImageRepository.swift in Sources */,
 				60DB54BD2C73852900AEDFE9 /* ManageMainViewModel.swift in Sources */,
 				60F27DF92C46039400711A53 /* QuestRepository.swift in Sources */,
+				60DB54CB2C73BF5500AEDFE9 /* ChallengeTarget.swift in Sources */,
 				60E696BB2B9A1BFE009DD235 /* ImageModel.swift in Sources */,
 				60E696AD2B97CC88009DD235 /* DataAssembly.swift in Sources */,
 				E5DD827F2B350D7200A026C2 /* NavigationBarComponent.swift in Sources */,

--- a/MatQ_Admin/App/DI/DataAssembly.swift
+++ b/MatQ_Admin/App/DI/DataAssembly.swift
@@ -25,6 +25,12 @@ final class DataAssembly: Assembly {
         ) -> QuestDataSource in
             return .init(networkService: resolver.resolve(NetworkServiceInterface.self)!)
         }).inObjectScope(.container)
+        
+        container.register(ChallengeDataSourceInterface.self, factory: { (
+            resolver: Resolver
+        ) -> ChallengeDataSource in
+            return .init(networkService: resolver.resolve(NetworkServiceInterface.self)!)
+        }).inObjectScope(.container)
 
         
         container.register(ImageDataSourceInterface.self, factory: { (
@@ -39,6 +45,12 @@ final class DataAssembly: Assembly {
             resolver: Resolver
         ) -> QuestRepository in
             return .init(questDataSource: resolver.resolve(QuestDataSourceInterface.self)!)
+        }).inObjectScope(.container)
+        
+         container.register(ChallengeRepositoryInterface.self, factory: { (
+            resolver: Resolver
+        ) -> ChallengeRepository in
+            return .init(challengeDataSource: resolver.resolve(ChallengeDataSourceInterface.self)!)
         }).inObjectScope(.container)
         
         container.register(ImageRepositoryInterface.self, factory: { (

--- a/MatQ_Admin/App/DI/DomainAssembly.swift
+++ b/MatQ_Admin/App/DI/DomainAssembly.swift
@@ -27,5 +27,24 @@ final class DomainAssembly: Assembly {
         ) -> DeleteQuestUseCase in
             return .init(questRepository: resolver.resolve(QuestRepositoryInterface.self)!)
         }).inObjectScope(.container)
+        
+        container.register(GetChallengeUseCaseInterface.self, factory: { (
+            resolver: Resolver
+        ) -> GetChallengeUseCase in
+            return .init(challengeRepository: resolver.resolve(ChallengeRepositoryInterface.self)!, imageRepository: resolver.resolve(ImageRepositoryInterface.self)!)
+        }).inObjectScope(.container)
+        
+        container.register(PatchChallengeUseCaseInterface.self, factory: { (
+            resolver: Resolver
+        ) -> PatchChallengeUseCase in
+            return .init(challengeRepository: resolver.resolve(ChallengeRepositoryInterface.self)!)
+        }).inObjectScope(.container)
+        
+        container.register(DeleteChallengeUseCaseInterface.self, factory: { (
+            resolver: Resolver
+        ) -> DeleteChallengeUseCase in
+            return .init(challengeRepository: resolver.resolve(ChallengeRepositoryInterface.self)!)
+        }).inObjectScope(.container)
+        
     }
 }

--- a/MatQ_Admin/App/DI/ViewAssembly.swift
+++ b/MatQ_Admin/App/DI/ViewAssembly.swift
@@ -37,7 +37,7 @@ final class ViewAssembly: Assembly {
         
         container.register(ManageDetailView.self, factory: { (
             resolver: Resolver,
-            arg1: Quest
+            arg1: Challenge
         ) -> ManageDetailView in
             return .init(vm: resolver.resolve(ManageDetailViewModel.self, argument: arg1)!)
         }).inObjectScope(.transient)

--- a/MatQ_Admin/App/DI/ViewModelAssembly.swift
+++ b/MatQ_Admin/App/DI/ViewModelAssembly.swift
@@ -11,7 +11,7 @@ final class ViewModelAssembly: Assembly {
     
     func assemble(container: Container) {
         // MARK: - Quest
-
+        
         container.register(QuestMainViewModel.self, factory: { (
             resolver: Resolver
         ) -> QuestMainViewModel in
@@ -23,7 +23,7 @@ final class ViewModelAssembly: Assembly {
             arg1: QuestDetailViewModel.ViewType,
             arg2: Quest
         ) -> QuestDetailViewModel in
-            return .init(viewType: arg1, 
+            return .init(viewType: arg1,
                          questDetail: arg2,
                          postQuestUseCase: resolver.resolve(PostQuestUseCaseInterface.self)!,
                          deleteQuestUseCase: resolver.resolve(DeleteQuestUseCaseInterface.self)!)
@@ -34,15 +34,16 @@ final class ViewModelAssembly: Assembly {
         container.register(ManageMainViewModel.self, factory: { (
             resolver: Resolver
         ) -> ManageMainViewModel in
-            return .init()
+            return .init(getChallengeUseCase: resolver.resolve(GetChallengeUseCaseInterface.self)!)
         }).inObjectScope(.container)
         
-        // TODO: Challenge 구조체로 변경
         container.register(ManageDetailViewModel.self, factory: { (
             resolver: Resolver,
-            arg1: Quest
+            arg1: Challenge
         ) -> ManageDetailViewModel in
-            return .init(challengeDetail: arg1)
+            return .init(challengeDetail: arg1,
+                         patchChallengeUseCase: resolver.resolve(PatchChallengeUseCaseInterface.self)!,
+                         deleteChallengeUseCase: resolver.resolve(DeleteChallengeUseCaseInterface.self)!)
         }).inObjectScope(.container)
     }
 }

--- a/MatQ_Admin/App/Router/NavigationStackRouter.swift
+++ b/MatQ_Admin/App/Router/NavigationStackRouter.swift
@@ -50,9 +50,8 @@ public class NavigationStackCoordinator: ObservableObject {
             injector?.resolve(QuestDetailView.self, argument1: type, argument2: quest)
         case .ManageMainView:
             injector?.resolve(ManageMainView.self)
-        case .ManageDetailView(let quest):
-            // TODO: CHALLENGE로 수정
-            injector?.resolve(ManageDetailView.self, argument: quest)
+        case .ManageDetailView(let challenge):
+            injector?.resolve(ManageDetailView.self, argument: challenge)
         }
     }
     
@@ -65,7 +64,7 @@ enum Path: Hashable {
     
     //Manage
     case ManageMainView
-    case ManageDetailView(quest: Quest)
+    case ManageDetailView(challenge: Challenge)
     
     func hash(into hasher: inout Hasher) {
         switch self {

--- a/MatQ_Admin/Data/DataSource/ChallengeDataSource.swift
+++ b/MatQ_Admin/Data/DataSource/ChallengeDataSource.swift
@@ -24,7 +24,7 @@ struct ChallengeDataSource: ChallengeDataSourceInterface {
     
     func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError> {
         networkService.request(ChallengeTarget.getChallenge(request), as: GetChallengeResponse.self)
-            .map { $0.data.content }
+            .map { $0.data }
             .eraseToAnyPublisher()
     }
     

--- a/MatQ_Admin/Data/DataSource/ChallengeDataSource.swift
+++ b/MatQ_Admin/Data/DataSource/ChallengeDataSource.swift
@@ -1,0 +1,38 @@
+//
+//  ChallengeDataSource.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Alamofire
+import Combine
+import Foundation
+
+protocol ChallengeDataSourceInterface {
+    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError>
+    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<PatchChallengeResponse, NetworkError>
+    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<DeleteChallengeResponse, NetworkError>
+}
+
+struct ChallengeDataSource: ChallengeDataSourceInterface {
+    private let networkService: NetworkServiceInterface
+    
+    init(networkService: NetworkServiceInterface) {
+        self.networkService = networkService
+    }
+    
+    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError> {
+        networkService.request(ChallengeTarget.getChallenge(request), as: GetChallengeResponse.self)
+            .map { $0.data.content }
+            .eraseToAnyPublisher()
+    }
+    
+    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<PatchChallengeResponse, NetworkError> {
+        networkService.request(ChallengeTarget.patchChallenge(request), as: PostQuestResponse.self)
+    }
+
+    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<DeleteChallengeResponse, NetworkError> {
+        networkService.request(ChallengeTarget.deleteChallenge(request), as: DeleteQuestResponse.self)
+    }
+}

--- a/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
@@ -14,12 +14,7 @@ struct GetChallengeRequest: Encodable {
     let size: Int = 50
 }
 
-//typealias GetChallengeResponse = ResponseWithPage<[GetChallengeResponseData]>
-typealias GetChallengeResponse = Response<Trash>
-
-struct Trash: Decodable {
-    let content: [GetChallengeResponseData]
-}
+typealias GetChallengeResponse = ResponseWithPage<[GetChallengeResponseData]>
 
 struct GetChallengeResponseData: Decodable {
     let challengeId: String

--- a/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
@@ -1,0 +1,69 @@
+//
+//  ChallengeModel.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Foundation
+import UIKit
+
+// MARK: - 챌린지 목록 조회
+struct GetChallengeRequest: Encodable {
+    let page: Int
+    let size: Int = 50
+}
+
+//typealias GetChallengeResponse = ResponseWithPage<[GetChallengeResponseData]>
+typealias GetChallengeResponse = Response<Trash>
+
+struct Trash: Decodable {
+    let content: [GetChallengeResponseData]
+}
+
+struct GetChallengeResponseData: Decodable {
+    let challengeId: String
+    let userNickName: String?
+    let quest: QuestResponse?
+    let receiptImageId, status: String
+    let createdAt: String
+    
+    func toDomain(image: UIImage?) -> Challenge {
+        return Challenge(challengeId: self.challengeId, userNickName: self.userNickName ?? "불러올 수 없음", quantity: self.quest?.rewards[0].quantity ?? 0, challengeTitle: self.quest?.missions[0].content ?? "불러올 수 없음", receiptImageId: self.receiptImageId, status: self.status, createdAt: self.createdAt, image: image)
+    }
+}
+
+struct QuestResponse: Decodable {
+    let questId: String
+    let missions: [MissionResponse]
+    let rewards: [RewardResponse]
+}
+
+struct MissionResponse: Decodable {
+    let content: String
+    let quantity: Int
+    let type: String
+}
+
+struct RewardResponse: Decodable {
+    let target: String
+    let quantity: Int
+    let type: String
+}
+
+
+// MARK: - 챌린지 상태 변경
+struct PatchChallengeRequest: Encodable {
+    let challengeId: String
+    let status: String
+}
+
+typealias PatchChallengeResponse = ResponseWithoutData
+
+
+// MARK: - 챌린지 삭제
+struct DeleteChallengeRequest: Encodable {
+    let challengeId: String
+}
+
+typealias DeleteChallengeResponse = ResponseWithoutData

--- a/MatQ_Admin/Data/Network/API/Target/ChallengeTarget.swift
+++ b/MatQ_Admin/Data/Network/API/Target/ChallengeTarget.swift
@@ -1,0 +1,48 @@
+//
+//  ChallengeTarget.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Alamofire
+import Foundation
+
+enum ChallengeTarget {
+    case getChallenge(GetChallengeRequest)
+    case patchChallenge(PatchChallengeRequest)
+    case deleteChallenge(DeleteChallengeRequest)
+}
+
+extension ChallengeTarget: TargetType {
+    var baseURL: String {
+        switch self {
+        case .getChallenge, .patchChallenge: return URL.makeEndPoint(.admin(endPoint: "report"))
+        case .deleteChallenge: return URL.makeEndPoint(.admin(endPoint: ""))
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .getChallenge: return .get
+        case .patchChallenge: return .patch
+        case .deleteChallenge: return .delete
+        }
+    }
+    
+    var path: String? {
+        switch self {
+        case .getChallenge: return nil
+        case .patchChallenge: return nil
+        case .deleteChallenge(let request): return request.challengeId
+        }
+    }
+    
+    var parameters: RequestParams {
+        switch self {
+        case .getChallenge(let request): return .query(request)
+        case .patchChallenge(let request): return .query(request)
+        case .deleteChallenge: return .query(.none)
+        }
+    }
+}

--- a/MatQ_Admin/Data/Repository/ChallengeRepository.swift
+++ b/MatQ_Admin/Data/Repository/ChallengeRepository.swift
@@ -1,0 +1,29 @@
+//
+//  ChallengeRepository.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Combine
+import UIKit
+
+final class ChallengeRepository: ChallengeRepositoryInterface {
+    let challengeDataSource: ChallengeDataSourceInterface
+    
+    init(challengeDataSource: ChallengeDataSourceInterface) {
+        self.challengeDataSource = challengeDataSource
+    }
+    
+    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError> {
+        challengeDataSource.getChallengeList(request: request)
+    }
+    
+    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<PatchChallengeResponse, NetworkError> {
+        challengeDataSource.patchChallenge(request: request)
+    }
+    
+    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<DeleteChallengeResponse, NetworkError> {
+        challengeDataSource.deleteChallenge(request: request)
+    }
+}

--- a/MatQ_Admin/Data/Repository/ChallengeRepository.swift
+++ b/MatQ_Admin/Data/Repository/ChallengeRepository.swift
@@ -15,15 +15,23 @@ final class ChallengeRepository: ChallengeRepositoryInterface {
         self.challengeDataSource = challengeDataSource
     }
     
-    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError> {
+    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[Challenge], NetworkError> {
         challengeDataSource.getChallengeList(request: request)
+            .map { response in
+                response.map { $0.toDomain(image: nil) }
+            }
+            .eraseToAnyPublisher()
     }
     
-    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<PatchChallengeResponse, NetworkError> {
+    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<Void, NetworkError> {
         challengeDataSource.patchChallenge(request: request)
+            .map { _ in }
+            .eraseToAnyPublisher()
     }
     
-    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<DeleteChallengeResponse, NetworkError> {
+    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<Void, NetworkError> {
         challengeDataSource.deleteChallenge(request: request)
+            .map { _ in }
+            .eraseToAnyPublisher()
     }
 }

--- a/MatQ_Admin/Data/Repository/QuestRepository.swift
+++ b/MatQ_Admin/Data/Repository/QuestRepository.swift
@@ -15,15 +15,23 @@ final class QuestRepository: QuestRepositoryInterface {
         self.questDataSource = questDataSource
     }
     
-    func getQuestList(request: GetQuestRequest) -> AnyPublisher<[GetQuestResponseData], NetworkError> {
+    func getQuestList(request: GetQuestRequest) -> AnyPublisher<[Quest], NetworkError> {
         questDataSource.getQuestList(request: request)
+            .map { response in
+                response.map { $0.toDomain(image: nil) }
+            }
+            .eraseToAnyPublisher()
     }
     
-    func postQuest(request: PostQuestRequest) -> AnyPublisher<PostQuestResponse, NetworkError> {
+    func postQuest(request: PostQuestRequest) -> AnyPublisher<Void, NetworkError> {
         questDataSource.postQuest(request: request)
+            .map { _ in }
+            .eraseToAnyPublisher()
     }
-    
-    func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<DeleteQuestResponse, NetworkError> {
+
+    func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<Void, NetworkError> {
         questDataSource.deleteQuest(request: request)
+            .map { _ in }
+            .eraseToAnyPublisher()
     }
 }

--- a/MatQ_Admin/Domain/Entity/Challenge.swift
+++ b/MatQ_Admin/Domain/Entity/Challenge.swift
@@ -1,0 +1,19 @@
+//
+//  Challenge.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import UIKit
+
+struct Challenge {
+    let challengeId: String
+    let userNickName: String
+    let quantity: Int
+    let challengeTitle: String
+    let receiptImageId: String?
+    let status: String
+    let createdAt: String
+    var image: UIImage?
+}

--- a/MatQ_Admin/Domain/RepositoryInterface/ChallengeRepositoryInterface.swift
+++ b/MatQ_Admin/Domain/RepositoryInterface/ChallengeRepositoryInterface.swift
@@ -8,7 +8,7 @@
 import Combine
 
 protocol ChallengeRepositoryInterface {
-    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError>
-    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<PatchChallengeResponse, NetworkError>
-    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<DeleteChallengeResponse, NetworkError>
+    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[Challenge], NetworkError>
+    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<Void, NetworkError>
+    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<Void, NetworkError>
 }

--- a/MatQ_Admin/Domain/RepositoryInterface/ChallengeRepositoryInterface.swift
+++ b/MatQ_Admin/Domain/RepositoryInterface/ChallengeRepositoryInterface.swift
@@ -1,0 +1,14 @@
+//
+//  ChallengeRepositoryInterface.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Combine
+
+protocol ChallengeRepositoryInterface {
+    func getChallengeList(request: GetChallengeRequest) -> AnyPublisher<[GetChallengeResponseData], NetworkError>
+    func patchChallenge(request: PatchChallengeRequest) -> AnyPublisher<PatchChallengeResponse, NetworkError>
+    func deleteChallenge(request: DeleteChallengeRequest) -> AnyPublisher<DeleteChallengeResponse, NetworkError>
+}

--- a/MatQ_Admin/Domain/RepositoryInterface/QuestRepositoryInterface.swift
+++ b/MatQ_Admin/Domain/RepositoryInterface/QuestRepositoryInterface.swift
@@ -8,7 +8,7 @@
 import Combine
 
 protocol QuestRepositoryInterface {
-    func getQuestList(request: GetQuestRequest) -> AnyPublisher<[GetQuestResponseData], NetworkError>
-    func postQuest(request: PostQuestRequest) -> AnyPublisher<PostQuestResponse, NetworkError>
-    func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<DeleteQuestResponse, NetworkError>
+    func getQuestList(request: GetQuestRequest) -> AnyPublisher<[Quest], NetworkError>
+    func postQuest(request: PostQuestRequest) -> AnyPublisher<Void, NetworkError>
+    func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<Void, NetworkError>
 }

--- a/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  DeleteChallengeUseCase.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Combine
+import Foundation
+
+protocol DeleteChallengeUseCaseInterface {
+    func execute(challengeId: String) -> AnyPublisher<DeleteChallengeResponse, NetworkError>
+}
+
+final class DeleteChallengeUseCase: DeleteChallengeUseCaseInterface {
+    let challengeRepository: ChallengeRepositoryInterface
+    
+    init(challengeRepository: ChallengeRepositoryInterface) {
+        self.challengeRepository = challengeRepository
+    }
+    
+    func execute(challengeId: String) -> AnyPublisher<DeleteChallengeResponse, NetworkError> {
+        let request = DeleteChallengeRequest(challengeId: challengeId)
+        
+        return challengeRepository.deleteChallenge(request: request)
+    }
+}

--- a/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 protocol DeleteChallengeUseCaseInterface {
-    func execute(challengeId: String) -> AnyPublisher<DeleteChallengeResponse, NetworkError>
+    func execute(challengeId: String) -> AnyPublisher<Void, NetworkError>
 }
 
 final class DeleteChallengeUseCase: DeleteChallengeUseCaseInterface {
@@ -19,7 +19,7 @@ final class DeleteChallengeUseCase: DeleteChallengeUseCaseInterface {
         self.challengeRepository = challengeRepository
     }
     
-    func execute(challengeId: String) -> AnyPublisher<DeleteChallengeResponse, NetworkError> {
+    func execute(challengeId: String) -> AnyPublisher<Void, NetworkError> {
         let request = DeleteChallengeRequest(challengeId: challengeId)
         
         return challengeRepository.deleteChallenge(request: request)

--- a/MatQ_Admin/Domain/UseCase/DeleteQuestUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/DeleteQuestUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 protocol DeleteQuestUseCaseInterface {
-    func execute(questId: String, type: QuestDeleteType) -> AnyPublisher<DeleteQuestResponse, NetworkError>
+    func execute(questId: String, type: QuestDeleteType) -> AnyPublisher<Void, NetworkError>
 }
 
 final class DeleteQuestUseCase: DeleteQuestUseCaseInterface {
@@ -20,7 +20,7 @@ final class DeleteQuestUseCase: DeleteQuestUseCaseInterface {
         self.questRepository = questRepository
     }
     
-    func execute(questId: String, type: QuestDeleteType) -> AnyPublisher<DeleteQuestResponse, NetworkError> {
+    func execute(questId: String, type: QuestDeleteType) -> AnyPublisher<Void, NetworkError> {
         self.questRepository.deleteQuest(request: DeleteQuestRequest(questId: DeleteQuestRequest.QuestId(questId: questId), deleteType: type))
     }
 }

--- a/MatQ_Admin/Domain/UseCase/GetChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/GetChallengeUseCase.swift
@@ -1,0 +1,62 @@
+//
+//  GetChallengeUseCase.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Combine
+import Foundation
+
+protocol GetChallengeUseCaseInterface {
+    func execute(page: Int) -> AnyPublisher<[Challenge], NetworkError>
+}
+
+final class GetChallengeUseCase: GetChallengeUseCaseInterface {
+    let challengeRepository: ChallengeRepositoryInterface
+    let imageRepository: ImageRepositoryInterface
+    
+    init(challengeRepository: ChallengeRepositoryInterface, imageRepository: ImageRepositoryInterface) {
+        self.challengeRepository = challengeRepository
+        self.imageRepository = imageRepository
+    }
+    
+    func execute(page: Int) -> AnyPublisher<[Challenge], NetworkError> {
+        let request = GetChallengeRequest(page: page)
+        
+        return challengeRepository.getChallengeList(request: request)
+            .flatMap { challenges in
+                let questsWithImages = challenges
+                    .map { $0.toDomain(image: nil) }
+                    .map { challenge -> AnyPublisher<Challenge, NetworkError> in
+                        
+                        // imageId가 없을 경우, 원래의 quest를 반환
+                        guard let imageId = challenge.receiptImageId, !imageId.isEmpty else {
+                            return Just(challenge)
+                                .setFailureType(to: NetworkError.self)
+                                .eraseToAnyPublisher()
+                        }
+                        
+                        // imageId가 있는 경우, 이미지를 로드하고 quest를 업데이트
+                        let imageRequest = GetImageRequest(imageId: imageId)
+                        
+                        return self.imageRepository.getImage(request: imageRequest)
+                            .map { image in
+                                var updatedQuest = challenge
+                                updatedQuest.image = image
+                                return updatedQuest
+                            }
+                            .catch { _ in
+                                Just(challenge)
+                                    .setFailureType(to: NetworkError.self)
+                            }
+                            .eraseToAnyPublisher()
+                    }
+                
+                return Publishers.MergeMany(questsWithImages)
+                    .collect()
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/MatQ_Admin/Domain/UseCase/GetChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/GetChallengeUseCase.swift
@@ -27,7 +27,6 @@ final class GetChallengeUseCase: GetChallengeUseCaseInterface {
         return challengeRepository.getChallengeList(request: request)
             .flatMap { challenges in
                 let questsWithImages = challenges
-                    .map { $0.toDomain(image: nil) }
                     .map { challenge -> AnyPublisher<Challenge, NetworkError> in
                         
                         // imageId가 없을 경우, 원래의 quest를 반환

--- a/MatQ_Admin/Domain/UseCase/GetQuestUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/GetQuestUseCase.swift
@@ -26,7 +26,6 @@ final class GetQuestUseCase: GetQuestUseCaseInterface {
         return questRepository.getQuestList(request: request)
             .flatMap { quests in
                 let questsWithImages = quests
-                    .map { $0.toDomain(image: nil) }
                     .map { quest -> AnyPublisher<Quest, NetworkError> in
                         
                         // imageId가 없을 경우, 원래의 quest를 반환

--- a/MatQ_Admin/Domain/UseCase/PatchChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/PatchChallengeUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 protocol PatchChallengeUseCaseInterface {
-    func execute(challengeId: String) -> AnyPublisher<PatchChallengeResponse, NetworkError>
+    func execute(challengeId: String) -> AnyPublisher<Void, NetworkError>
 }
 
 final class PatchChallengeUseCase: PatchChallengeUseCaseInterface {
@@ -19,7 +19,7 @@ final class PatchChallengeUseCase: PatchChallengeUseCaseInterface {
         self.challengeRepository = challengeRepository
     }
     
-    func execute(challengeId: String) -> AnyPublisher<PatchChallengeResponse, NetworkError> {
+    func execute(challengeId: String) -> AnyPublisher<Void, NetworkError> {
         // status ==> APPROVED,REPORTED,REJECTED
         let request = PatchChallengeRequest(challengeId: challengeId, status: "APPROVED")
         

--- a/MatQ_Admin/Domain/UseCase/PatchChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/PatchChallengeUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  PatchChallengeUseCase.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 8/20/24.
+//
+
+import Combine
+import Foundation
+
+protocol PatchChallengeUseCaseInterface {
+    func execute(challengeId: String) -> AnyPublisher<PatchChallengeResponse, NetworkError>
+}
+
+final class PatchChallengeUseCase: PatchChallengeUseCaseInterface {
+    let challengeRepository: ChallengeRepositoryInterface
+    
+    init(challengeRepository: ChallengeRepositoryInterface) {
+        self.challengeRepository = challengeRepository
+    }
+    
+    func execute(challengeId: String) -> AnyPublisher<PatchChallengeResponse, NetworkError> {
+        // status ==> APPROVED,REPORTED,REJECTED
+        let request = PatchChallengeRequest(challengeId: challengeId, status: "APPROVED")
+        
+        return challengeRepository.patchChallenge(request: request)
+    }
+}

--- a/MatQ_Admin/Domain/UseCase/PostQuestUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/PostQuestUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import UIKit
 
 protocol PostQuestUseCaseInterface {
-    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<PostQuestResponse, NetworkError>
+    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<Void, NetworkError>
 }
 
 final class PostQuestUseCase: PostQuestUseCaseInterface {
@@ -23,7 +23,7 @@ final class PostQuestUseCase: PostQuestUseCaseInterface {
     }
     
     // TODO: 책임 분리
-    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<PostQuestResponse, NetworkError> {
+    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<Void, NetworkError> {
         // image가 없으면 imageId를 사용
         if let image = image {
             return uploadImageAndPostQuest(
@@ -49,7 +49,7 @@ final class PostQuestUseCase: PostQuestUseCaseInterface {
         }
     }
     
-    private func uploadImageAndPostQuest(image: UIImage, writer: String, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<PostQuestResponse, NetworkError> {
+    private func uploadImageAndPostQuest(image: UIImage, writer: String, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<Void, NetworkError> {
         var uiImage = image
         if image.size.width > 1500 || image.size.height > 1500 {
             print("RESIZE IMAGE \(image.size.width) \(image.size.height)")

--- a/MatQ_Admin/Presentation/View/Manage/ManageDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Manage/ManageDetailView.swift
@@ -15,34 +15,35 @@ struct ManageDetailView: View {
         VStack(spacing: 0) {
             NavigationBarComponent(navigationTitle: "신고된 챌린지 관리", isNotRoot: true)
             
-            Spacer().frame(height: 20)
+            Spacer().frame(height: 16)
             
             VStack(alignment: .leading, spacing: 16) {
-                Image(uiImage: vm.items.questImage ?? .testimage)
-                    .renderingMode(.template)
-                    .tint(.red)
+                Image(uiImage: vm.item.image ?? .testimage)
+                    .resizable()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 420)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .shadow(color: .gray200.opacity(0.2), radius: 8)
-                    .background(
+                    .background(alignment: .bottom, content: {
                         RoundedRectangle(cornerRadius: 16)
                             .foregroundStyle(.componentPrimary)
                             .scaleEffect(0.9)
                             .offset(y: 32)
-                    )
-                    .padding(.bottom, 20)
+                    })
+                    .padding(.bottom, 12)
                 
                 HStack(spacing: 12) {
-                    Text("바닐라라떼 마시기")
+                    Text(vm.item.questTitle)
                         .font(.title2).bold()
                         .foregroundStyle(.textPrimary)
                     
-                    Text("\(50)XP")
+                    Text("\(vm.item.quantity)XP")
                         .font(.headline)
                         .foregroundStyle(.primaryPurple)
                 }
                 
-                textView(title: "작성자", content: "일상1234")
-                textView(title: "업로드 날짜", content: "2024.01.01")
+                textView(title: "작성자", content: "\(vm.item.userNickname)")
+                textView(title: "업로드 날짜", content: "\(vm.item.createdAt)")
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 20)
@@ -51,15 +52,15 @@ struct ManageDetailView: View {
             
             HStack(spacing: 8) {
                 Button {
-                    vm.showAlert = true
                     vm.activeAlertType = .recovery
+                    vm.showAlert = true
                 } label: {
                     Text("철회")
                 }
                 .ilsangButtonStyle(type: .secondary)
                 Button {
-                    vm.showAlert = true
                     vm.activeAlertType = .delete
+                    vm.showAlert = true
                 } label: {
                     Text("삭제")
                 }
@@ -75,8 +76,7 @@ struct ManageDetailView: View {
                     message: Text("삭제한 챌린지는 복구할 수 없으며 미완료 상태로 변경됩니다."),
                     primaryButton: .cancel(Text("취소")),
                     secondaryButton: .destructive(Text("삭제")) {
-                        // TODO: 챌린지 id 연결
-                        vm.deleteChallenge(challengeId: "")
+                        vm.deleteChallenge(challengeId: vm.item.challengeId)
                     }
                 )
             case .recovery:
@@ -85,8 +85,7 @@ struct ManageDetailView: View {
                     message: Text("챌린지는 완료 상태로 복구됩니다."),
                     primaryButton: .cancel(Text("취소")),
                     secondaryButton: .destructive(Text("신고 철회")) {
-                        // TODO: 챌린지 id 연결
-                        vm.recoveryChallenge(challengeId: "")
+                        vm.recoveryChallenge(challengeId: vm.item.challengeId)
                     }
                 )
             case .result:
@@ -94,8 +93,7 @@ struct ManageDetailView: View {
                     title: Text(vm.alertTitle),
                     message: Text(vm.alertMessage),
                     dismissButton: .default(Text("확인")) {
-                        // TODO: title 확인 필요
-                        if vm.alertTitle == "퀘스트 복구 성공" || vm.alertTitle == "퀘스트 삭제 성공" {
+                        if vm.alertTitle == "챌린지 신고 철회 성공" || vm.alertTitle == "챌린지 삭제 성공" {
                             router.pop()
                         }
                     }


### PR DESCRIPTION
- 디자인 수정
- 신고된 챌린지 목록 조회 API 연결
- 신고된 챌린지 삭제 API 연결
- 신고된 챌린지 상태 변경 API 연결
- [레이어간 인터페이스 반환값 변경(도메인레이어가 데이터레이어를 알지 못하도록 변경)](https://github.com/TeamFair/meokQ-Admin-iOS/pull/58/commits/b7cd7033a2cdfedeea2846f94d7850b32e52166e)