### PR TITLE
[Feat/#60] UIImage 사이즈 열거형 및 리사이즈 로직 구현, 이미지 로드 시 리사이즈 처리

### DIFF
--- a/MatQ_Admin/App/Extension/UIImage++.swift
+++ b/MatQ_Admin/App/Extension/UIImage++.swift
@@ -26,17 +26,14 @@ extension UIImage {
         return UIImage(cgImage: scaledImage, scale: self.scale, orientation: self.imageOrientation)
     }
     
-    func resizeImage(newWidth: CGFloat) -> UIImage? {
+    func resizeImage(newWidth: CGFloat) -> UIImage {
         let scale = newWidth / self.size.width
         let newHeight = self.size.height * scale
         let newSize = CGSize(width: newWidth, height: newHeight)
-        
-        UIGraphicsBeginImageContextWithOptions(newSize, false, UIScreen.main.scale)
-        self.draw(in: CGRect(origin: .zero, size: newSize))
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return newImage
+      
+        return UIGraphicsImageRenderer(size: newSize).image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
     }
 }
 

--- a/MatQ_Admin/App/Extension/UIImage++.swift
+++ b/MatQ_Admin/App/Extension/UIImage++.swift
@@ -25,4 +25,37 @@ extension UIImage {
 
         return UIImage(cgImage: scaledImage, scale: self.scale, orientation: self.imageOrientation)
     }
+    
+    func resizeImage(newWidth: CGFloat) -> UIImage? {
+        let scale = newWidth / self.size.width
+        let newHeight = self.size.height * scale
+        let newSize = CGSize(width: newWidth, height: newHeight)
+        
+        UIGraphicsBeginImageContextWithOptions(newSize, false, UIScreen.main.scale)
+        self.draw(in: CGRect(origin: .zero, size: newSize))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return newImage
+    }
+}
+
+enum UIImageSize {
+    case small
+    case medium
+    case maxWidth
+    case custom(CGFloat)
+    
+    var value: CGFloat {
+        switch self {
+        case .small:
+            return 76
+        case .medium:
+            return 160
+        case .maxWidth:
+            return UIScreen.main.bounds.width - 40
+        case .custom(let size):
+            return size
+        }
+    }
 }

--- a/MatQ_Admin/Domain/UseCase/GetChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/GetChallengeUseCase.swift
@@ -42,7 +42,7 @@ final class GetChallengeUseCase: GetChallengeUseCaseInterface {
                         return self.imageRepository.getImage(request: imageRequest)
                             .map { image in
                                 var updatedQuest = challenge
-                                updatedQuest.image = image
+                                updatedQuest.image = image.resizeImage(newWidth: UIImageSize.maxWidth.value)
                                 return updatedQuest
                             }
                             .catch { _ in

--- a/MatQ_Admin/Domain/UseCase/GetQuestUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/GetQuestUseCase.swift
@@ -41,7 +41,7 @@ final class GetQuestUseCase: GetQuestUseCaseInterface {
                         return self.imageRepository.getImage(request: imageRequest)
                             .map { image in
                                 var updatedQuest = quest
-                                updatedQuest.image = image
+                                updatedQuest.image = image.resizeImage(newWidth: UIImageSize.medium.value) // 32
                                 return updatedQuest
                             }
                             .catch { _ in

--- a/MatQ_Admin/Presentation/Component/TextFieldComponent.swift
+++ b/MatQ_Admin/Presentation/Component/TextFieldComponent.swift
@@ -43,20 +43,19 @@ struct ImageFieldComponent: View {
                 .font(.subheadline).bold()
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(.textPrimary)
-
-            if let image = uiImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .frame(width: 160, height: 160)
-                    .cornerRadius(12)
-                    .frame(maxWidth: .infinity)
-            } else {
-                RoundedRectangle(cornerRadius: 12)
-                    .frame(width: 160, height: 160)
-                    .cornerRadius(12)
-                    .foregroundStyle(.regularMaterial)
-                    .frame(maxWidth: .infinity)
+            
+            Group {
+                if let image = uiImage {
+                    Image(uiImage: image)
+                        .resizable()
+                } else {
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(.regularMaterial)
+                }
             }
+            .frame(width: UIImageSize.medium.value, height: UIImageSize.medium.value)
+            .cornerRadius(12)
+            .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)
         .padding(.bottom, 16)

--- a/MatQ_Admin/Presentation/View/Manage/ManageDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Manage/ManageDetailView.swift
@@ -20,8 +20,8 @@ struct ManageDetailView: View {
             VStack(alignment: .leading, spacing: 16) {
                 Image(uiImage: vm.item.image ?? .testimage)
                     .resizable()
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 420)
+                    .scaledToFill()
+                    .frame(width: UIImageSize.maxWidth.value, height: 400)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .shadow(color: .gray200.opacity(0.2), radius: 8)
                     .background(alignment: .bottom, content: {

--- a/MatQ_Admin/Presentation/View/Quest/QuestItemView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestItemView.swift
@@ -16,7 +16,7 @@ struct QuestItemView: View {
         HStack(spacing: 0){
             Image(uiImage: questImage)
                 .resizable()
-                .frame(width: 76, height: 76)
+                .frame(width: UIImageSize.small.value, height: UIImageSize.small.value)
                 .cornerRadius(10)
                 .padding(.trailing, 14)
             VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
- **리사이즈 이유**
 큰 이미지 & 복잡한 이미지가 아니지만, 메모리가 많이 사용되는 문제를 조금 개선하고 싶었음
- **환경/상황**
기기 빌드 & 이미지 30개 로드 
- **결과**
    - 개선 전 >> 메모리 약 63MB 소요 
    - 개선 후 >> 메모리 약 32MB 소요

- **UIGraphicsImageRenderer 사용 이유**
    - 복잡한 그래픽이나 계산에는 CG가 적합하지만, 현재 서버에 저장하고 불러오는 이미지는 전부 100kb로 매우!매우! 작은 상황임.
    - 즉, 들어오는 데이터들이 고해상도&큰 이미지일 가능성이 없는 상황이기 때문에 간단한 처리에 적합한 UIGraphicsBeginImageContextWithOptions를 사용하려했으나, `deprecated`가 달려있음.
    - 확인해보니 UIGraphicsImageRenderer / ImageIO(CGImageSourceCreateWithURL~..) 선택지가 있었음
    - 둘 다 확인해본 결과, 100Kb인 이미지를 리사이즈하는데 ImageIO로 했을 때 화질이 더 뭉개져서, UIGraphicsImageRenderer를 사용하기로 결정. (UIGraphicsImageRenderer 메모리 릭이 있다는 글을 확인했는데, 일단 이 방법으로 할 예정..)

### 시험 결과 메모리 확인
| 상황 | 메모리 확인 |
|--------|--------|
 | 개선 전 |  <img width="500" src="https://github.com/user-attachments/assets/ac9e653f-ce92-4eec-9f66-721abbcab968"> |
|  **UIGraphicsBeginImageContextWithOptions 사용(deprecated)** | <img width="500" src="https://github.com/user-attachments/assets/bad572e5-5ee6-46a0-b8c3-6ad76cc4bc01"> | 
| **UIGraphicsImageRenderer 사용** | <img width="500" src="https://github.com/user-attachments/assets/53a19dd5-e8e3-41b0-a82d-4a6ab696e291"> |
 | **ImageIO 사용** | <img width="500" src="https://github.com/user-attachments/assets/9b1dac39-eac3-4a08-b9a4-08692f7e27cf"> |

### 사용 메서드별 화질
이미지 리스트도 있는데, 사이즈가 작기 때문에 큰 차이는 안느껴지기 때문에 보다 큰 이미지로 비교.
| UIGraphicsImageRenderer 사용 | ImageIO 사용 |
|--------|--------|
| <img src = "https://github.com/user-attachments/assets/9eaf2a2e-4179-4fcd-9cca-a2b79452ff11" width = "300"> | <img src = "https://github.com/user-attachments/assets/d8a9bb4c-8853-4864-b1dc-3465d781626f" width = "300"> | 
