### PR TITLE
[Feat/#62] 신고된 도전내역 삭제 시 이미지도 삭제하도록 구현

### DIFF
--- a/MatQ_Admin/App/DI/DomainAssembly.swift
+++ b/MatQ_Admin/App/DI/DomainAssembly.swift
@@ -43,7 +43,8 @@ final class DomainAssembly: Assembly {
         container.register(DeleteChallengeUseCaseInterface.self, factory: { (
             resolver: Resolver
         ) -> DeleteChallengeUseCase in
-            return .init(challengeRepository: resolver.resolve(ChallengeRepositoryInterface.self)!)
+            return .init(challengeRepository: resolver.resolve(ChallengeRepositoryInterface.self)!, 
+                         imageRepository: resolver.resolve(ImageRepositoryInterface.self)!)
         }).inObjectScope(.container)
         
     }

--- a/MatQ_Admin/App/DI/ViewModelAssembly.swift
+++ b/MatQ_Admin/App/DI/ViewModelAssembly.swift
@@ -44,6 +44,6 @@ final class ViewModelAssembly: Assembly {
             return .init(challengeDetail: arg1,
                          patchChallengeUseCase: resolver.resolve(PatchChallengeUseCaseInterface.self)!,
                          deleteChallengeUseCase: resolver.resolve(DeleteChallengeUseCaseInterface.self)!)
-        }).inObjectScope(.container)
+        }).inObjectScope(.transient)
     }
 }

--- a/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
@@ -20,7 +20,8 @@ struct GetChallengeResponseData: Decodable {
     let challengeId: String
     let userNickName: String?
     let quest: QuestResponse?
-    let receiptImageId, status: String
+    let receiptImageId: String?
+    let status: String
     let createdAt: String
     
     func toDomain(image: UIImage?) -> Challenge {

--- a/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
@@ -14,9 +14,11 @@ protocol DeleteChallengeUseCaseInterface {
 
 final class DeleteChallengeUseCase: DeleteChallengeUseCaseInterface {
     let challengeRepository: ChallengeRepositoryInterface
+    let imageRepository: ImageRepositoryInterface
     
-    init(challengeRepository: ChallengeRepositoryInterface) {
+    init(challengeRepository: ChallengeRepositoryInterface, imageRepository: ImageRepositoryInterface) {
         self.challengeRepository = challengeRepository
+        self.imageRepository = imageRepository
     }
     
     func execute(challengeId: String) -> AnyPublisher<Void, NetworkError> {

--- a/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/DeleteChallengeUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 protocol DeleteChallengeUseCaseInterface {
-    func execute(challengeId: String) -> AnyPublisher<Void, NetworkError>
+    func execute(challengeId: String, imageId: String?) -> AnyPublisher<Void, NetworkError>
 }
 
 final class DeleteChallengeUseCase: DeleteChallengeUseCaseInterface {
@@ -21,9 +21,34 @@ final class DeleteChallengeUseCase: DeleteChallengeUseCaseInterface {
         self.imageRepository = imageRepository
     }
     
-    func execute(challengeId: String) -> AnyPublisher<Void, NetworkError> {
-        let request = DeleteChallengeRequest(challengeId: challengeId)
+    /// #62 PR 로직 설명 참고
+    func execute(challengeId: String, imageId: String?) -> AnyPublisher<Void, NetworkError> {
+        let challengeRequest = DeleteChallengeRequest(challengeId: challengeId+"ddd")
         
-        return challengeRepository.deleteChallenge(request: request)
+        if let imageId = imageId {
+            let imageRequest = DeleteImageRequest(imageId: imageId)
+            
+            return imageRepository.deleteImage(request: imageRequest)
+                .map { _ in }
+                .catch { error -> AnyPublisher<Void, NetworkError> in
+                    // 이미지 삭제 실패하더라도 406에러(NOT_FOUND_DATA)인 경우는 챌린지 삭제 작업 수행
+                    if case let NetworkError.error((_, status, _)) = error, status == "NOT_FOUND_DATA" {
+                        return Just(())
+                            .setFailureType(to: NetworkError.self)
+                            .eraseToAnyPublisher()
+                    } else {
+                        return Fail(error: error)
+                            .eraseToAnyPublisher()
+                    }
+                }
+                .flatMap { _ in  // 이미지 삭제 성공 후 챌린지 삭제 작업 수행
+                    return self.challengeRepository.deleteChallenge(request: challengeRequest)
+                }
+                .eraseToAnyPublisher()
+        } else {
+            return challengeRepository.deleteChallenge(request: challengeRequest)
+                .mapError { _ in NetworkError.unknownError }
+                .eraseToAnyPublisher()
+        }
     }
 }

--- a/MatQ_Admin/Presentation/View/Manage/ManageDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Manage/ManageDetailView.swift
@@ -76,7 +76,7 @@ struct ManageDetailView: View {
                     message: Text("삭제한 챌린지는 복구할 수 없으며 미완료 상태로 변경됩니다."),
                     primaryButton: .cancel(Text("취소")),
                     secondaryButton: .destructive(Text("삭제")) {
-                        vm.deleteChallenge(challengeId: vm.item.challengeId)
+                        vm.deleteChallenge(item: vm.item)
                     }
                 )
             case .recovery:


### PR DESCRIPTION
close #62 

- 처음 생각했던 로직
이미지 삭제 API와 챌린지 삭제 API를 별개로 비동기로 요청해도 되지만, 
**상황에 따라 이미지 삭제는 실패했는데 챌린지 삭제는 성공하여 이미지는 그대로 서버에 쌓여있는 문제를 방지하고자,** 
이미지 삭제를 성공하면 챌린지 삭제를 요청하도록 설계를 했다.
  - ImageId 있으면
     - 1-a. 이미지 삭제 시도 (성공) -> 챌린지 삭제 시도 (성공)
     - 1-b. 이미지 삭제 시도 (성공) -> 챌린지 삭제 시도 (실패)         ===> 챌린지 리스트 남아있어 다음에 다시 시도 가능
     - 1-c. 이미지 삭제 시도 (실패) -> 챌린지 삭제 시도 안함 X         ===> 챌린지 리스트 남아있어 다음에 다시 시도 가능
    
  - ImageId 없으면
     - 2-a. 챌린지 삭제 시도 (성공)
     - 2-b. 챌린지 삭제 시도 (실패)                               ===> 챌린지 리스트 남아있어 다음에 다시 시도 가능

- 구현하면서 발견한 문제
     - 이미지를 삭제하면 챌린지를 다시 조회했을 때 이미지 id가 null로 들어올 것으로 예상했으나,
     이미지를 삭제했음에도, 이전 이미지 ID를 유지한 채 응답해주는 문제가 있었다.
     따라서 기존 로직으로는 계속 1-c 플로우로 진행되어 챌린지 삭제를 진행하지 못하는 상황이다.
     _(ImageId는 존재하여 해당 아이디로 서버에 삭제해달라고 요청하지만, 서버에는 아이디에 해당하는 이미지가 이미 삭제되어 없기 때문에 상태코드 406, "NOT_FOUND_DATA"로 실패를 응답해주기 때문이다.)_
     ==> 백엔드팀에 물어보니 실패를 고려하지 않고 비동기로 한 번에 요청할 것으로 생각하여, s3에서 이미지 삭제만 진행하고 있었다.

- **해결방법 요약**
      - 결론적으로는 기존 로직으로는 해결할 수 없고, 이미지 삭제를 한 번 시도해서 디코딩한 에러의 status가 "NOT_FOUND_DATA"이면 챌린지를 삭제하도록 개선하기로 했다. 따라서 #57 을 선행해서 구현했다.

- 최종 챌린지 & 이미지 삭제 로직 ([868cdb9](https://github.com/TeamFair/meokQ-Admin-iOS/pull/70/commits/868cdb9d1b0a7dbc7f9e567f903f93a4393bbdf1))
  - ImageId 있으면
     - 1-a. 이미지 삭제 시도 (성공) -> 챌린지 삭제 시도 (성공)
     - 1-b. 이미지 삭제 시도 (성공) -> 챌린지 삭제 시도 (실패)         ===> 챌린지 리스트 남아있어 다음에 다시 시도 가능
     - 1-c. 이미지 삭제 시도 (실패) -> 챌린지 삭제 시도 안함 X         ===> 챌린지 리스트 남아있어 다음에 다시 시도 가능
     - **1-d. 이미지 삭제 시도 (406 실패) -> 챌린지 삭제 시도 (성공)                       <<<<< 서버 로직 고려하여 추가된 부분**

  - ImageId 없으면
     - 2-a. 챌린지 삭제 시도 (성공)
     - 2-b. 챌린지 삭제 시도 (실패)                               ===> 챌린지 리스트 남아있어 다음에 다시 시도 가능

