### PR TITLE
[UX/#75] 하단액션버튼 위치 수정 (safeAreaInset 활용)

### DIFF
--- a/MatQ_Admin/App/Extension/Button.swift
+++ b/MatQ_Admin/App/Extension/Button.swift
@@ -15,9 +15,9 @@ struct IS_ButonStyle: ButtonStyle {
         configuration.label
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .foregroundColor(type.fgColor.opacity(isDisabled ? 0.8 : 1.0))
+            .foregroundColor(isDisabled ? ButtonType.secondary.fgColor: type.fgColor)
             .font(.headline)
-            .background(isDisabled ? type.bgColor.opacity(0.3) : (configuration.isPressed ? type.bgColor.opacity(0.7) : type.bgColor))
+            .background(isDisabled ? ButtonType.secondary.bgColor : (configuration.isPressed ? type.bgColor.opacity(0.7) : type.bgColor))
             .cornerRadius(12)
             .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
             .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
@@ -34,7 +34,7 @@ struct IS_ButonStyle: ButtonStyle {
             case .primary:
                 Color.white
             case .secondary:
-                Color.black.opacity(0.8)
+                Color.gray500
             case .delete:
                 Color.white
             }
@@ -45,7 +45,7 @@ struct IS_ButonStyle: ButtonStyle {
             case .primary:
                 Color.primaryPurple
             case .secondary:
-                Color.gray100
+                Color.gray200
             case .delete:
                 Color.mainRed
             }

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
@@ -64,18 +64,6 @@ struct QuestDetailView: View {
                 }
                 .padding(.horizontal, 20)
             }
-            
-            if vm.viewType == .publish {
-                Button {
-                    // TODO: 퀘스트 수정 API 연결
-                    vm.createData(data: vm.editedItems)
-                } label: {
-                    Text(vm.viewType.buttonTitle)
-                }
-                .ilsangButtonStyle(type: .primary, isDisabled: vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
-                .disabled(vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
-                .padding(.horizontal, 20)
-            }
         }
         .alert(isPresented: $vm.showAlert) {
             switch vm.activeAlertType {
@@ -100,6 +88,20 @@ struct QuestDetailView: View {
                 )
             case .none:
                 Alert(title: Text(""))
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            if vm.viewType == .publish {
+                Button {
+                    // TODO: 퀘스트 수정 API 연결
+                    vm.createData(data: vm.editedItems)
+                } label: {
+                    Text(vm.viewType.buttonTitle)
+                }
+                .ilsangButtonStyle(type: .primary, isDisabled: vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
+                .disabled(vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 8)
             }
         }
     }

--- a/MatQ_Admin/Presentation/View/Quest/QuestMainView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestMainView.swift
@@ -48,7 +48,8 @@ struct QuestMainView: View {
             case .loaded:
                 marketListView
             }
-            
+        }
+        .safeAreaInset(edge: .bottom) {
             Button {
                 router.push(.QuestDetailView(type: .publish, quest: Quest.init()))
             } label: {
@@ -56,7 +57,7 @@ struct QuestMainView: View {
             }
             .ilsangButtonStyle(type: .primary)
             .padding(.horizontal)
-            .padding(.bottom, 12)
+            .padding(.bottom, 8)
         }
         .background(.bgSecondary)
         .task {


### PR DESCRIPTION
다음 경우에 safeAreaInset 활용하면 쉽고 간결하게 원하는 레이아웃을 구성할 수 있음
- 목록의 하단에 오버레이하는 경우
- 뷰의 하단 & 키보드 위에 위치 하는 경우

ZStack이나 overlay로 구현할 수 있으나, safeAreaInset을 통해 복잡한 계산 없이도 직관적으로 레이아웃을 구현할 수 있음.
특히, 뷰가 safe area를 침범하지 않도록 자동으로 조정되므로 더 안전하고 효율적인 레이아웃 설계가 가능해짐.

</br>

#### Before & After
하단에 목록 내용이 보이고 안보이고의 차이가 있음.

| Before(VStack) | After(safeAreaInset) |
|--------|--------|
| <img src = "https://github.com/user-attachments/assets/3b6f545a-3c0a-435e-be3f-09a10fb861d0" width = "160"> | <img src = "https://github.com/user-attachments/assets/a26bac56-5553-4b2f-8a61-66b801f5ea92" width = "160"> |

</br>

#### After(safeAreaInset) QuestMainView 결과 

| 스크롤 안한 상태 | 스크롤 중인 상태 | 스크롤 완료한 상태 | 스크롤 완료한 상태 (+하단 여백) |
|--------|--------|--------|--------|
| <img src = "https://github.com/user-attachments/assets/8f4229ef-8482-44b8-b4dc-e8d8e961c894" width = "160">  | <img src = "https://github.com/user-attachments/assets/a26bac56-5553-4b2f-8a61-66b801f5ea92" width = "160">  | <img src = "https://github.com/user-attachments/assets/dfc2b85a-0a3f-4696-80c4-b159cfbe22f2" width = "160">  | <img src = "https://github.com/user-attachments/assets/4683a0a7-f6c8-4793-9a7e-e41034209936" width = "160">  | 

* 명확하게 마지막이라는 걸 표현하고자4번째는 하단에 추가로 여백을 줌 (Spacer(minLength: 60)

</br>

#### After(safeAreaInset) QuestDetailView 결과

| 키보드 비활성화 상태 | 키보드 활성화 상태 |
|--------|--------|
| <img src = "https://github.com/user-attachments/assets/2131ba61-b2d0-4308-8138-bc39c8353be8" width = "300"> |<img src = "https://github.com/user-attachments/assets/c84346df-e9cc-4a49-bfd4-037c87d0dcd6" width = "300"> |

