### PR TITLE
[Feat/#78] 위젯 타겟 추가 및 기본 작업

### DIFF
--- a/ILSANG_ADMIN_WIDGET/AppIntent.swift
+++ b/ILSANG_ADMIN_WIDGET/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  ILSANG_ADMIN_WIDGET
+//
+//  Created by Lee Jinhee on 9/1/24.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Configuration"
+    static var description = IntentDescription("This is an example widget.")
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/ILSANG_ADMIN_WIDGET/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ILSANG_ADMIN_WIDGET/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG_ADMIN_WIDGET/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ILSANG_ADMIN_WIDGET/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG_ADMIN_WIDGET/Assets.xcassets/Contents.json
+++ b/ILSANG_ADMIN_WIDGET/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG_ADMIN_WIDGET/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/ILSANG_ADMIN_WIDGET/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ILSANG_ADMIN_WIDGET/ILSANG_ADMIN_WIDGET.swift
+++ b/ILSANG_ADMIN_WIDGET/ILSANG_ADMIN_WIDGET.swift
@@ -1,0 +1,84 @@
+//
+//  ILSANG_ADMIN_WIDGET.swift
+//  ILSANG_ADMIN_WIDGET
+//
+//  Created by Lee Jinhee on 9/1/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: configuration)
+    }
+    
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationAppIntent
+}
+
+struct ILSANG_ADMIN_WIDGETEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Favorite Emoji:")
+            Text(entry.configuration.favoriteEmoji)
+        }
+    }
+}
+
+struct ILSANG_ADMIN_WIDGET: Widget {
+    let kind: String = "ILSANG_ADMIN_WIDGET"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+            ILSANG_ADMIN_WIDGETEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+    }
+}
+
+extension ConfigurationAppIntent {
+    fileprivate static var smiley: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "😀"
+        return intent
+    }
+    
+    fileprivate static var starEyes: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "🤩"
+        return intent
+    }
+}
+
+#Preview(as: .systemSmall) {
+    ILSANG_ADMIN_WIDGET()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley)
+    SimpleEntry(date: .now, configuration: .starEyes)
+}

--- a/ILSANG_ADMIN_WIDGET/ILSANG_ADMIN_WIDGETBundle.swift
+++ b/ILSANG_ADMIN_WIDGET/ILSANG_ADMIN_WIDGETBundle.swift
@@ -1,0 +1,16 @@
+//
+//  ILSANG_ADMIN_WIDGETBundle.swift
+//  ILSANG_ADMIN_WIDGET
+//
+//  Created by Lee Jinhee on 9/1/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct ILSANG_ADMIN_WIDGETBundle: WidgetBundle {
+    var body: some Widget {
+        ILSANG_ADMIN_WIDGET()
+    }
+}

--- a/ILSANG_ADMIN_WIDGET/Info.plist
+++ b/ILSANG_ADMIN_WIDGET/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/MatQ_Admin.xcodeproj/project.pbxproj
+++ b/MatQ_Admin.xcodeproj/project.pbxproj
@@ -53,6 +53,13 @@
 		60E696BF2B9A1FC1009DD235 /* ImageDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E696BE2B9A1FC1009DD235 /* ImageDataSource.swift */; };
 		60EC51F82B9CB075002CBCA3 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 60EC51F72B9CB075002CBCA3 /* Swinject */; };
 		60EC52002B9D99CE002CBCA3 /* View++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EC51FF2B9D99CE002CBCA3 /* View++.swift */; };
+		60ECFBC82C8459800020E24B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60ECFBC72C8459800020E24B /* WidgetKit.framework */; };
+		60ECFBCA2C8459800020E24B /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60ECFBC92C8459800020E24B /* SwiftUI.framework */; };
+		60ECFBCD2C8459800020E24B /* ILSANG_ADMIN_WIDGETBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ECFBCC2C8459800020E24B /* ILSANG_ADMIN_WIDGETBundle.swift */; };
+		60ECFBCF2C8459800020E24B /* ILSANG_ADMIN_WIDGET.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ECFBCE2C8459800020E24B /* ILSANG_ADMIN_WIDGET.swift */; };
+		60ECFBD12C8459800020E24B /* AppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ECFBD02C8459800020E24B /* AppIntent.swift */; };
+		60ECFBD32C8459820020E24B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60ECFBD22C8459820020E24B /* Assets.xcassets */; };
+		60ECFBD72C8459820020E24B /* MatQ_Admin_Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 60ECFBC62C8459800020E24B /* MatQ_Admin_Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		60F27DED2C45691F00711A53 /* QuestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F27DEC2C45691F00711A53 /* QuestModel.swift */; };
 		60F27DEF2C45F1A900711A53 /* CommonResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F27DEE2C45F1A900711A53 /* CommonResponse.swift */; };
 		60F27DF12C45FADC00711A53 /* QuestTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F27DF02C45FADC00711A53 /* QuestTarget.swift */; };
@@ -73,6 +80,16 @@
 		E5DD827F2B350D7200A026C2 /* NavigationBarComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DD827E2B350D7200A026C2 /* NavigationBarComponent.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		60ECFBD52C8459820020E24B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E5DD824E2B34DCCA00A026C2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 60ECFBC52C8459800020E24B;
+			remoteInfo = ILSANG_ADMIN_WIDGETExtension;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		60EC51F42B9CAE5A002CBCA3 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -82,6 +99,17 @@
 			files = (
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		60ECFBD82C8459820020E24B /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				60ECFBD72C8459820020E24B /* MatQ_Admin_Extension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -132,6 +160,16 @@
 		60E696BC2B9A1ED4009DD235 /* ImageTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTarget.swift; sourceTree = "<group>"; };
 		60E696BE2B9A1FC1009DD235 /* ImageDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataSource.swift; sourceTree = "<group>"; };
 		60EC51FF2B9D99CE002CBCA3 /* View++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View++.swift"; sourceTree = "<group>"; };
+		60ECFBC62C8459800020E24B /* MatQ_Admin_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MatQ_Admin_Extension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		60ECFBC72C8459800020E24B /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		60ECFBC92C8459800020E24B /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		60ECFBCC2C8459800020E24B /* ILSANG_ADMIN_WIDGETBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANG_ADMIN_WIDGETBundle.swift; sourceTree = "<group>"; };
+		60ECFBCE2C8459800020E24B /* ILSANG_ADMIN_WIDGET.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ILSANG_ADMIN_WIDGET.swift; sourceTree = "<group>"; };
+		60ECFBD02C8459800020E24B /* AppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntent.swift; sourceTree = "<group>"; };
+		60ECFBD22C8459820020E24B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		60ECFBD42C8459820020E24B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		60ECFBDC2C8461450020E24B /* MatQ_Admin.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MatQ_Admin.entitlements; sourceTree = "<group>"; };
+		60ECFBDD2C8463450020E24B /* MatQ_Admin_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MatQ_Admin_Extension.entitlements; sourceTree = "<group>"; };
 		60F27DEC2C45691F00711A53 /* QuestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestModel.swift; sourceTree = "<group>"; };
 		60F27DEE2C45F1A900711A53 /* CommonResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResponse.swift; sourceTree = "<group>"; };
 		60F27DF02C45FADC00711A53 /* QuestTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestTarget.swift; sourceTree = "<group>"; };
@@ -154,6 +192,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		60ECFBC32C8459800020E24B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60ECFBCA2C8459800020E24B /* SwiftUI.framework in Frameworks */,
+				60ECFBC82C8459800020E24B /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E5DD82532B34DCCA00A026C2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -378,14 +425,30 @@
 		60EC51F12B9CAE5A002CBCA3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				60ECFBC72C8459800020E24B /* WidgetKit.framework */,
+				60ECFBC92C8459800020E24B /* SwiftUI.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		60ECFBCB2C8459800020E24B /* ILSANG_ADMIN_WIDGET */ = {
+			isa = PBXGroup;
+			children = (
+				60ECFBCC2C8459800020E24B /* ILSANG_ADMIN_WIDGETBundle.swift */,
+				60ECFBCE2C8459800020E24B /* ILSANG_ADMIN_WIDGET.swift */,
+				60ECFBD02C8459800020E24B /* AppIntent.swift */,
+				60ECFBD22C8459820020E24B /* Assets.xcassets */,
+				60ECFBD42C8459820020E24B /* Info.plist */,
+			);
+			path = ILSANG_ADMIN_WIDGET;
 			sourceTree = "<group>";
 		};
 		E5DD824D2B34DCCA00A026C2 = {
 			isa = PBXGroup;
 			children = (
+				60ECFBDD2C8463450020E24B /* MatQ_Admin_Extension.entitlements */,
 				E5DD82582B34DCCA00A026C2 /* MatQ_Admin */,
+				60ECFBCB2C8459800020E24B /* ILSANG_ADMIN_WIDGET */,
 				E5DD82572B34DCCA00A026C2 /* Products */,
 				60EC51F12B9CAE5A002CBCA3 /* Frameworks */,
 			);
@@ -395,6 +458,7 @@
 			isa = PBXGroup;
 			children = (
 				E5DD82562B34DCCA00A026C2 /* MatQ_Admin.app */,
+				60ECFBC62C8459800020E24B /* MatQ_Admin_Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -402,6 +466,7 @@
 		E5DD82582B34DCCA00A026C2 /* MatQ_Admin */ = {
 			isa = PBXGroup;
 			children = (
+				60ECFBDC2C8461450020E24B /* MatQ_Admin.entitlements */,
 				60DA56FD2B940C4500EDAF30 /* App */,
 				60DA56FF2B940D3300EDAF30 /* Data */,
 				60DA57032B940D8000EDAF30 /* Domain */,
@@ -463,6 +528,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		60ECFBC52C8459800020E24B /* MatQ_Admin_Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 60ECFBDB2C8459820020E24B /* Build configuration list for PBXNativeTarget "MatQ_Admin_Extension" */;
+			buildPhases = (
+				60ECFBC22C8459800020E24B /* Sources */,
+				60ECFBC32C8459800020E24B /* Frameworks */,
+				60ECFBC42C8459800020E24B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MatQ_Admin_Extension;
+			productName = ILSANG_ADMIN_WIDGETExtension;
+			productReference = 60ECFBC62C8459800020E24B /* MatQ_Admin_Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		E5DD82552B34DCCA00A026C2 /* MatQ_Admin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E5DD82642B34DCCB00A026C2 /* Build configuration list for PBXNativeTarget "MatQ_Admin" */;
@@ -471,10 +553,12 @@
 				E5DD82532B34DCCA00A026C2 /* Frameworks */,
 				E5DD82542B34DCCA00A026C2 /* Resources */,
 				60EC51F42B9CAE5A002CBCA3 /* Embed Frameworks */,
+				60ECFBD82C8459820020E24B /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				60ECFBD62C8459820020E24B /* PBXTargetDependency */,
 			);
 			name = MatQ_Admin;
 			packageProductDependencies = (
@@ -491,9 +575,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1510;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1510;
 				TargetAttributes = {
+					60ECFBC52C8459800020E24B = {
+						CreatedOnToolsVersion = 15.0;
+					};
 					E5DD82552B34DCCA00A026C2 = {
 						CreatedOnToolsVersion = 15.1;
 					};
@@ -517,11 +604,20 @@
 			projectRoot = "";
 			targets = (
 				E5DD82552B34DCCA00A026C2 /* MatQ_Admin */,
+				60ECFBC52C8459800020E24B /* MatQ_Admin_Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		60ECFBC42C8459800020E24B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60ECFBD32C8459820020E24B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E5DD82542B34DCCA00A026C2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -535,6 +631,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		60ECFBC22C8459800020E24B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60ECFBCD2C8459800020E24B /* ILSANG_ADMIN_WIDGETBundle.swift in Sources */,
+				60ECFBCF2C8459800020E24B /* ILSANG_ADMIN_WIDGET.swift in Sources */,
+				60ECFBD12C8459800020E24B /* AppIntent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E5DD82522B34DCCA00A026C2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -603,7 +709,73 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		60ECFBD62C8459820020E24B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 60ECFBC52C8459800020E24B /* MatQ_Admin_Extension */;
+			targetProxy = 60ECFBD52C8459820020E24B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		60ECFBD92C8459820020E24B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = MatQ_Admin_Extension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = VJUK3HBJ2M;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ILSANG_ADMIN_WIDGET/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ILSANG_ADMIN_WIDGET;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.teamfair.MatQ-Admin.widget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		60ECFBDA2C8459820020E24B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = MatQ_Admin_Extension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = VJUK3HBJ2M;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ILSANG_ADMIN_WIDGET/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ILSANG_ADMIN_WIDGET;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.teamfair.MatQ-Admin.widget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		E5DD82622B34DCCB00A026C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -727,8 +899,10 @@
 		E5DD82652B34DCCB00A026C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = MatQ_Admin/MatQ_Admin.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -768,8 +942,10 @@
 		E5DD82662B34DCCB00A026C2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = MatQ_Admin/MatQ_Admin.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -808,6 +984,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		60ECFBDB2C8459820020E24B /* Build configuration list for PBXNativeTarget "MatQ_Admin_Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60ECFBD92C8459820020E24B /* Debug */,
+				60ECFBDA2C8459820020E24B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E5DD82512B34DCCA00A026C2 /* Build configuration list for PBXProject "MatQ_Admin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MatQ_Admin.xcodeproj/xcuserdata/leejinhee.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/MatQ_Admin.xcodeproj/xcuserdata/leejinhee.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,31 +4,41 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
+		<key>ILSANG_ADMIN_WIDGETExtension.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
 		<key>MatQ_Admin.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>0</integer>
+		</dict>
+		<key>MatQ_Admin_Extension.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
 		</dict>
 		<key>Sample-iOS (Playground) 1.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>Sample-iOS (Playground) 2.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<key>Sample-iOS (Playground).xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/MatQ_Admin/MatQ_Admin.entitlements
+++ b/MatQ_Admin/MatQ_Admin.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.teamfair.MatQ-Admin</string>
+	</array>
+</dict>
+</plist>

--- a/MatQ_Admin_Extension.entitlements
+++ b/MatQ_Admin_Extension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.teamfair.MatQ-Admin</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
related #78

- 타겟에 위젯 추가
    - 프로젝트 파일 - TARGETS - +버튼 - Widget Extension 선택 - Bundle Identifier를 기존 앱 번들id +”.abcd” 이런식으로 구성   
- 애플 개발자 사이트에서 app group id 추가
- 타겟 - 앱 선택 - +Capability 버튼 - App Group 선택 - 사용할 앱 그룹 선택 ( 여기서 + 버튼으로 그룹아이디 추가 가능 )
- 타겟 - 위젯 선택 - +Capability 버튼 - App Group 선택 - 사용할 앱 그룹 선택