### PR TITLE
[Ref/#85] 퀘스트 응답 구조 변경(스탯 분리에 따른 퀘스트 조회&생성 API 변경 사항 반영)

### DIFF
--- a/MatQ_Admin.xcodeproj/project.pbxproj
+++ b/MatQ_Admin.xcodeproj/project.pbxproj
@@ -957,7 +957,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.1.5;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamfair.MatQ-Admin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -999,7 +999,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.1.5;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamfair.MatQ-Admin";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/ChallengeModel.swift
@@ -42,7 +42,7 @@ struct MissionResponse: Decodable {
 }
 
 struct RewardResponse: Decodable {
-    let target: String
+    let content: String?
     let quantity: Int
     let type: String
 }

--- a/MatQ_Admin/Data/Network/API/DTO/QuestModel.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/QuestModel.swift
@@ -17,18 +17,12 @@ struct GetQuestRequest: Encodable {
 
 typealias GetQuestResponse = ResponseWithPage<[GetQuestResponseData]>
 struct GetQuestResponseData: Decodable {
-    let questId: String
-    let writer: String
-    let marketId: String?
-    // TODO: 백엔드에서 테스트로 넣어둔 값 지워달라 요청하기
-    let quantity: Int?
-    let missionTitle: String?
-    let status: String
-    let expireDate: String
+    let questId, writer, missionTitle, status, expireDate: String
     let imageId: String?
-    
+    let rewardList: [RewardResponse]
+
     func toDomain(image: UIImage?) -> Quest {
-        Quest(questId: self.questId, missionTitle: self.missionTitle ?? "불러올 수 없음", quantity: self.quantity ?? 0, status: self.status, writer: self.writer, image: image, logoImageId: self.imageId ?? "", expireDate: self.expireDate)
+        Quest(questId: self.questId, missionTitle: self.missionTitle, rewardList: self.rewardList, status: self.status, writer: self.writer, image: image, logoImageId: self.imageId ?? "", expireDate: self.expireDate)
     }
 }
 
@@ -48,7 +42,7 @@ struct Mission: Encodable {
 }
 
 struct Reward: Encodable {
-    let target: String = ""
+    let content: String?
     let quantity: Int
     let type: String = "XP"
 }

--- a/MatQ_Admin/Domain/Entity/Quest.swift
+++ b/MatQ_Admin/Domain/Entity/Quest.swift
@@ -10,17 +10,17 @@ import UIKit
 struct Quest {
     let questId: String
     let missionTitle: String
-    let quantity: Int
+    let rewardList: [RewardResponse]
     let status: String
     let writer: String
     var image: UIImage?
     let logoImageId: String?
     let expireDate: String
     
-    init(questId: String, missionTitle: String, quantity: Int, status: String, writer: String, image: UIImage? ,logoImageId: String, expireDate: String) {
+    init(questId: String, missionTitle: String, rewardList: [RewardResponse], status: String, writer: String, image: UIImage? ,logoImageId: String, expireDate: String) {
         self.questId = questId
         self.missionTitle = missionTitle
-        self.quantity = quantity
+        self.rewardList = rewardList
         self.status = status
         self.writer = writer
         self.image = image
@@ -31,7 +31,7 @@ struct Quest {
     init() {
         self.questId = UUID().uuidString
         self.missionTitle = ""
-        self.quantity = 50
+        self.rewardList = []
         self.status = ""
         self.writer = "일상"
         self.image = .testimage
@@ -40,7 +40,7 @@ struct Quest {
     }
     
     static let initialData = Quest.init()
-    static let mockData1 = Quest.init(questId: UUID().uuidString, missionTitle: "밥먹기", quantity: 50, status: "", writer: "이기욱", image: nil, logoImageId: "", expireDate: "2024-12-31")
-    static let mockData2 = Quest.init(questId: UUID().uuidString, missionTitle: "커피 마시기", quantity: 50, status: "", writer: "이기욱", image: nil, logoImageId: "", expireDate: "2024-12-31")
+    static let mockData1 = Quest.init(questId: UUID().uuidString, missionTitle: "밥먹기", rewardList: [], status: "", writer: "이기욱", image: nil, logoImageId: "", expireDate: "2024-12-31")
+    static let mockData2 = Quest.init(questId: UUID().uuidString, missionTitle: "커피 마시기", rewardList: [], status: "", writer: "이기욱", image: nil, logoImageId: "", expireDate: "2024-12-31")
     static let defaultLogoImageId = "IMMA2024072114492808"
 }

--- a/MatQ_Admin/Domain/UseCase/PostQuestUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/PostQuestUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import UIKit
 
 protocol PostQuestUseCaseInterface {
-    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<Void, NetworkError>
+    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, rewardList: [Reward], expireDate: String) -> AnyPublisher<Void, NetworkError>
 }
 
 final class PostQuestUseCase: PostQuestUseCaseInterface {
@@ -23,14 +23,14 @@ final class PostQuestUseCase: PostQuestUseCaseInterface {
     }
     
     // TODO: 책임 분리
-    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<Void, NetworkError> {
+    func execute(writer: String, image: UIImage?, imageId: String?, missionTitle: String, rewardList: [Reward], expireDate: String) -> AnyPublisher<Void, NetworkError> {
         // image가 없으면 imageId를 사용
         if let image = image {
             return uploadImageAndPostQuest(
                 image: image,
                 writer: writer,
                 missionTitle: missionTitle,
-                quantity: quantity,
+                rewardList: rewardList,
                 expireDate: expireDate
             )
         } else if let imageId = imageId {
@@ -39,7 +39,7 @@ final class PostQuestUseCase: PostQuestUseCaseInterface {
                     writer: writer,
                     imageId: imageId,
                     missions: [.init(content: missionTitle)],
-                    rewards: [.init(quantity: quantity)],
+                    rewards: rewardList,
                     expireDate: expireDate
                 )
             )
@@ -49,7 +49,7 @@ final class PostQuestUseCase: PostQuestUseCaseInterface {
         }
     }
     
-    private func uploadImageAndPostQuest(image: UIImage, writer: String, missionTitle: String, quantity: Int, expireDate: String) -> AnyPublisher<Void, NetworkError> {
+    private func uploadImageAndPostQuest(image: UIImage, writer: String, missionTitle: String, rewardList: [Reward], expireDate: String) -> AnyPublisher<Void, NetworkError> {
         var uiImage = image
         if image.size.width > 1500 || image.size.height > 1500 {
             print("RESIZE IMAGE \(image.size.width) \(image.size.height)")
@@ -83,7 +83,7 @@ final class PostQuestUseCase: PostQuestUseCaseInterface {
                         writer: writer,
                         imageId: newImageId,
                         missions: [.init(content: missionTitle)],
-                        rewards: [.init(quantity: quantity)],
+                        rewards: rewardList,
                         expireDate: expireDate
                     )
                 )

--- a/MatQ_Admin/Presentation/Component/TextFieldComponent.swift
+++ b/MatQ_Admin/Presentation/Component/TextFieldComponent.swift
@@ -16,6 +16,7 @@ struct TextFieldComponent: View {
         VStack(alignment: .leading){
             Text(titleName)
                 .font(.subheadline).bold()
+                .foregroundStyle(.textSecondary)
             if let contentPlaceholder = contentPlaceholder {
                 TextField("\(contentPlaceholder)", text: $content)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -28,7 +29,28 @@ struct TextFieldComponent: View {
                     )
             }
         }
-        .padding(.bottom, 16)
+    }
+}
+
+struct SliderComponent: View {
+    let titleName: String
+    let contentPlaceholder: Int
+    @Binding var content: Double
+    
+    var body: some View {
+        HStack(spacing: 2) {
+            Text(titleName)
+                .font(.subheadline)
+                .frame(width: 36)
+            Text("\(Int(content))")
+                .frame(width: 32)
+            Slider(value: $content, in: 0...100, step: 5)
+                .frame(maxWidth: .infinity)
+        }
+        .foregroundStyle(.textPrimary)
+        .tint(.primaryPurple)
+        .padding(.vertical, 4)
+        .padding(.horizontal)
     }
 }
 
@@ -42,8 +64,7 @@ struct ImageFieldComponent: View {
             Text(titleName)
                 .font(.subheadline).bold()
                 .multilineTextAlignment(.leading)
-                .foregroundStyle(.textPrimary)
-            
+                .foregroundStyle(.textSecondary)
             Group {
                 if let image = uiImage {
                     Image(uiImage: image)

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
@@ -50,7 +50,41 @@ struct QuestDetailView: View {
                                 .padding(.trailing, 8)
                                 .offset(y: 2)
                         }
-                    TextFieldComponent(titleName: "리워드 XP", contentPlaceholder: String(vm.items.xpCount), content: $vm.editedItems.xpCount)
+                 
+                    VStack(alignment: .leading) {
+                        Text("스탯")
+                            .font(.subheadline).bold()
+                            .foregroundStyle(.textSecondary)
+
+                        VStack {
+                            SliderComponent(titleName: "체력", contentPlaceholder: vm.items.strengthXP, content: Binding(
+                                get: { Double(vm.editedItems.strengthXP) },
+                                set: { vm.editedItems.strengthXP = Int($0) }
+                            ))
+                            SliderComponent(titleName: "지능", contentPlaceholder: vm.items.intellectXP, content: Binding(
+                                get: { Double(vm.editedItems.intellectXP) },
+                                set: { vm.editedItems.intellectXP = Int($0) }
+                            ))
+                            SliderComponent(titleName: "재미", contentPlaceholder: vm.items.funXP, content: Binding(
+                                get: { Double(vm.editedItems.funXP) },
+                                set: { vm.editedItems.funXP = Int($0) }
+                            ))
+                            SliderComponent(titleName: "매력", contentPlaceholder: vm.items.charmXP, content: Binding(
+                                get: { Double(vm.editedItems.charmXP) },
+                                set: { vm.editedItems.charmXP = Int($0) }
+                            ))
+                            SliderComponent(titleName: "사회성", contentPlaceholder: vm.items.sociabilityXP, content: Binding(
+                                get: { Double(vm.editedItems.sociabilityXP) },
+                                set: { vm.editedItems.sociabilityXP = Int($0) }
+                            ))
+                        }
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .foregroundStyle(.componentPrimary)
+                        )
+                    }
+                    
                     TextFieldComponent(titleName: "작성자", contentPlaceholder: vm.items.writer, content: $vm.editedItems.writer)
                     TextFieldComponent(titleName: "만료 기한", contentPlaceholder: vm.items.expireDate, content: $vm.editedItems.expireDate)
                     
@@ -99,7 +133,7 @@ struct QuestDetailView: View {
                 } label: {
                     Text(vm.viewType.buttonTitle)
                 }
-                .ilsangButtonStyle(type: .primary, isDisabled: vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
+                .ilsangButtonStyle(type: .primary, isDisabled: vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0) // TODO: 스탯모두 0이면 생성 불가
                 .disabled(vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
                 .padding(.horizontal, 20)
                 .padding(.bottom, 8)

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
@@ -85,7 +85,24 @@ final class QuestDetailViewModel: ObservableObject {
     let deleteQuestUseCase: DeleteQuestUseCaseInterface
     
     func createData(data: QuestDetailViewModelItem) {
-        postQuestUseCase.execute(writer: data.writer, image: data.questImage, imageId: data.imageId, missionTitle: data.questTitle, quantity: Int(data.xpCount)!, expireDate: data.expireDate)
+        var rewardList: [Reward] = []
+        if data.strengthXP != 0 {
+            rewardList.append(Reward(content: "STRENGTH", quantity: data.strengthXP))
+        }
+        if data.intellectXP != 0 {
+            rewardList.append(Reward(content: "INTELLECT", quantity: data.intellectXP))
+        } 
+        if data.funXP != 0 {
+            rewardList.append(Reward(content: "FUN", quantity: data.funXP))
+        }
+        if data.charmXP != 0 {
+            rewardList.append(Reward(content: "CHARM", quantity: data.charmXP))
+        }
+        if data.sociabilityXP != 0 {
+            rewardList.append(Reward(content: "SOCIABILITY", quantity: data.sociabilityXP))
+        }
+       
+        postQuestUseCase.execute(writer: data.writer, image: data.questImage, imageId: data.imageId, missionTitle: data.questTitle, rewardList: rewardList, expireDate: data.expireDate)
             .sink { [weak self] completion in
                 if case .failure(let error) = completion {
                     self?.alertTitle = "퀘스트 추가 실패"
@@ -124,7 +141,11 @@ final class QuestDetailViewModel: ObservableObject {
 struct QuestDetailViewModelItem: Equatable {
     let questId: String
     var questTitle: String
-    var xpCount: String
+    var strengthXP: Int
+    var intellectXP: Int
+    var funXP: Int
+    var charmXP: Int
+    var sociabilityXP: Int
     var writer: String
     var expireDate: String
     let imageId: String?
@@ -133,7 +154,11 @@ struct QuestDetailViewModelItem: Equatable {
     init(quest: Quest) {
         self.questId = quest.questId
         self.questTitle = quest.missionTitle
-        self.xpCount = String(quest.quantity)
+        self.strengthXP = quest.rewardList.first(where: { $0.content == "STRENGTH" })?.quantity ?? 0
+        self.intellectXP = quest.rewardList.first(where: { $0.content == "INTELLECT" })?.quantity ?? 0
+        self.funXP = quest.rewardList.first(where: { $0.content == "FUN" })?.quantity ?? 0
+        self.charmXP = quest.rewardList.first(where: { $0.content == "CHARM" })?.quantity ?? 0
+        self.sociabilityXP = quest.rewardList.first(where: { $0.content == "SOCIABILITY" })?.quantity ?? 0
         self.writer = quest.writer
         self.expireDate = quest.expireDate
         self.imageId = quest.logoImageId

--- a/MatQ_Admin/Presentation/View/Quest/QuestMainView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestMainView.swift
@@ -82,7 +82,7 @@ struct QuestMainView: View {
                                     Quest(
                                         questId: $0.questId,
                                         missionTitle: $0.missionTitle,
-                                        quantity: $0.quantity,
+                                        rewardList: $0.rewardList,
                                         status: $0.status,
                                         writer: $0.writer,
                                         image: $0.image,


### PR DESCRIPTION
XP를 5개의 스탯으로 분리함에 따라 퀘스트 조회&생성 API 응답 구조가 변경되어, 이를 적용합니다.
- [x] 퀘스트 조회 API 변경사항 적용
- [x] 퀘스트 생성 API 변경사항 적용
 
<img src = "https://github.com/user-attachments/assets/04062c5f-7b6e-4bb7-8161-bf6a12d91233" width = "300">

