### PR TITLE
[Feat/#91] 퀘스트 수정 API 연결

### DIFF
--- a/MatQ_Admin.xcodeproj/project.pbxproj
+++ b/MatQ_Admin.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		60631E092C85E764005643B1 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60631E072C85E761005643B1 /* Provider.swift */; };
 		606329932C7483E8000F4513 /* PatchChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */; };
 		606329952C748E10000F4513 /* DeleteChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */; };
+		6073BEBD2CA2B8DA00072FF9 /* PutQuestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6073BEBC2CA2B8DA00072FF9 /* PutQuestUseCase.swift */; };
 		608EBF8A2C38709800B862CC /* AppInject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF892C38709800B862CC /* AppInject.swift */; };
 		608EBF8D2C38716100B862CC /* QuestMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF8C2C38716100B862CC /* QuestMainView.swift */; };
 		608EBF8F2C38716900B862CC /* QuestDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF8E2C38716900B862CC /* QuestDetailView.swift */; };
@@ -135,6 +136,7 @@
 		60631E072C85E761005643B1 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchChallengeUseCase.swift; sourceTree = "<group>"; };
 		606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteChallengeUseCase.swift; sourceTree = "<group>"; };
+		6073BEBC2CA2B8DA00072FF9 /* PutQuestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutQuestUseCase.swift; sourceTree = "<group>"; };
 		608EBF892C38709800B862CC /* AppInject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInject.swift; sourceTree = "<group>"; };
 		608EBF8C2C38716100B862CC /* QuestMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMainView.swift; sourceTree = "<group>"; };
 		608EBF8E2C38716900B862CC /* QuestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestDetailView.swift; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 			children = (
 				60F27DF42C4602DD00711A53 /* GetQuestUseCase.swift */,
 				60F27DFA2C4616D500711A53 /* PostQuestUseCase.swift */,
+				6073BEBC2CA2B8DA00072FF9 /* PutQuestUseCase.swift */,
 				60F27DFC2C461B2B00711A53 /* DeleteQuestUseCase.swift */,
 				60DB54D02C73C1F900AEDFE9 /* GetChallengeUseCase.swift */,
 				606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */,
@@ -698,6 +701,7 @@
 				60DB54CD2C73C12600AEDFE9 /* ChallengeRepository.swift in Sources */,
 				608EBF8D2C38716100B862CC /* QuestMainView.swift in Sources */,
 				60DB54B12C7272E400AEDFE9 /* NetworkService.swift in Sources */,
+				6073BEBD2CA2B8DA00072FF9 /* PutQuestUseCase.swift in Sources */,
 				60F27DFB2C4616D500711A53 /* PostQuestUseCase.swift in Sources */,
 				E5DD825C2B34DCCA00A026C2 /* MainView.swift in Sources */,
 				608EBF912C3871DF00B862CC /* QuestMainViewModel.swift in Sources */,

--- a/MatQ_Admin.xcodeproj/project.pbxproj
+++ b/MatQ_Admin.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		606329932C7483E8000F4513 /* PatchChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */; };
 		606329952C748E10000F4513 /* DeleteChallengeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */; };
 		6073BEBD2CA2B8DA00072FF9 /* PutQuestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6073BEBC2CA2B8DA00072FF9 /* PutQuestUseCase.swift */; };
+		6073BEC22CA31C3000072FF9 /* String++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6073BEC12CA31C3000072FF9 /* String++.swift */; };
 		608EBF8A2C38709800B862CC /* AppInject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF892C38709800B862CC /* AppInject.swift */; };
 		608EBF8D2C38716100B862CC /* QuestMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF8C2C38716100B862CC /* QuestMainView.swift */; };
 		608EBF8F2C38716900B862CC /* QuestDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608EBF8E2C38716900B862CC /* QuestDetailView.swift */; };
@@ -137,6 +138,7 @@
 		606329922C7483E8000F4513 /* PatchChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchChallengeUseCase.swift; sourceTree = "<group>"; };
 		606329942C748E10000F4513 /* DeleteChallengeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteChallengeUseCase.swift; sourceTree = "<group>"; };
 		6073BEBC2CA2B8DA00072FF9 /* PutQuestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutQuestUseCase.swift; sourceTree = "<group>"; };
+		6073BEC12CA31C3000072FF9 /* String++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String++.swift"; sourceTree = "<group>"; };
 		608EBF892C38709800B862CC /* AppInject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInject.swift; sourceTree = "<group>"; };
 		608EBF8C2C38716100B862CC /* QuestMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMainView.swift; sourceTree = "<group>"; };
 		608EBF8E2C38716900B862CC /* QuestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestDetailView.swift; sourceTree = "<group>"; };
@@ -437,6 +439,7 @@
 				60EC51FF2B9D99CE002CBCA3 /* View++.swift */,
 				608EBF9A2C393C2600B862CC /* Button.swift */,
 				601048702C652FC20028662D /* UIImage++.swift */,
+				6073BEC12CA31C3000072FF9 /* String++.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -694,6 +697,7 @@
 				60F27DFD2C461B2B00711A53 /* DeleteQuestUseCase.swift in Sources */,
 				608EBF972C390C5200B862CC /* QuestDetailViewModel.swift in Sources */,
 				608EBF952C38758100B862CC /* QuestItemView.swift in Sources */,
+				6073BEC22CA31C3000072FF9 /* String++.swift in Sources */,
 				60E696AF2B97CDE2009DD235 /* DomainAssembly.swift in Sources */,
 				608EBF932C3872D700B862CC /* Quest.swift in Sources */,
 				60DA570C2B94124F00EDAF30 /* NetworkError.swift in Sources */,

--- a/MatQ_Admin/App/DI/DomainAssembly.swift
+++ b/MatQ_Admin/App/DI/DomainAssembly.swift
@@ -22,6 +22,12 @@ final class DomainAssembly: Assembly {
             return .init(questRepository: resolver.resolve(QuestRepositoryInterface.self)!, imageRepository: resolver.resolve(ImageRepositoryInterface.self)!)
         }).inObjectScope(.container)
         
+        container.register(PutQuestUseCaseInterface.self, factory: { (
+            resolver: Resolver
+        ) -> PutQuestUseCase in
+            return .init(questRepository: resolver.resolve(QuestRepositoryInterface.self)!, imageRepository: resolver.resolve(ImageRepositoryInterface.self)!)
+        }).inObjectScope(.container)
+        
         container.register(DeleteQuestUseCaseInterface.self, factory: { (
             resolver: Resolver
         ) -> DeleteQuestUseCase in

--- a/MatQ_Admin/App/DI/ViewModelAssembly.swift
+++ b/MatQ_Admin/App/DI/ViewModelAssembly.swift
@@ -26,6 +26,7 @@ final class ViewModelAssembly: Assembly {
             return .init(viewType: arg1,
                          questDetail: arg2,
                          postQuestUseCase: resolver.resolve(PostQuestUseCaseInterface.self)!,
+                         putQuestUseCase: resolver.resolve(PutQuestUseCaseInterface.self)!,
                          deleteQuestUseCase: resolver.resolve(DeleteQuestUseCaseInterface.self)!)
         }).inObjectScope(.transient)
         

--- a/MatQ_Admin/App/Extension/String++.swift
+++ b/MatQ_Admin/App/Extension/String++.swift
@@ -1,0 +1,32 @@
+//
+//  String++.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 9/25/24.
+//
+
+import Foundation
+
+extension String {
+    
+    /// 서버에서 보내주는 시간을 "30-12-31" 형식으로 날짜 포맷 변환.
+    ///
+    /// 서버 응답 예시들: 3125-01-02T00:00:00, 2024-07-04T00:31:57.313048
+    func timeAgoSinceDate() -> String {
+        let date = self.split(separator: ".")
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        
+        guard let date = dateFormatter.date(from: String(date[0])) else { return "2030-12-31" }
+       
+        // 날짜 포맷 설정
+        let dateFormat = "yyyy-MM-dd"
+        
+        // 설정한 포맷으로 변환
+        dateFormatter.dateFormat = dateFormat
+        let formattedDate = dateFormatter.string(from: date)
+        
+        return formattedDate
+    }
+}

--- a/MatQ_Admin/Data/DataSource/QuestDataSource.swift
+++ b/MatQ_Admin/Data/DataSource/QuestDataSource.swift
@@ -12,6 +12,7 @@ import Foundation
 protocol QuestDataSourceInterface {
     func getQuestList(request: GetQuestRequest) -> AnyPublisher<[GetQuestResponseData], NetworkError>
     func postQuest(request: PostQuestRequest) -> AnyPublisher<PostQuestResponse, NetworkError>
+    func putQuest(request: PutQuestRequest) -> AnyPublisher<PutQuestResponse, NetworkError>
     func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<PostQuestResponse, NetworkError>
 }
 
@@ -32,6 +33,10 @@ struct QuestDataSource: QuestDataSourceInterface {
         networkService.request(QuestTarget.postQuest(request), as: PostQuestResponse.self)
     }
 
+    func putQuest(request: PutQuestRequest) -> AnyPublisher<PutQuestResponse, NetworkError> {
+        networkService.request(QuestTarget.putQuest(request), as: PutQuestResponse.self)
+    }
+    
     func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<DeleteQuestResponse, NetworkError> {
         networkService.request(QuestTarget.deleteQuest(request), as: DeleteQuestResponse.self)
     }

--- a/MatQ_Admin/Data/Network/API/DTO/QuestModel.swift
+++ b/MatQ_Admin/Data/Network/API/DTO/QuestModel.swift
@@ -23,7 +23,17 @@ struct GetQuestResponseData: Decodable {
     let score: Int
     
     func toDomain(image: UIImage?) -> Quest {
-        Quest(questId: self.questId, missionTitle: self.missionTitle, rewardList: self.rewardList, status: self.status, writer: self.writer, image: image, logoImageId: self.imageId ?? "", expireDate: self.expireDate, score: self.score)
+        Quest(
+            questId: self.questId,
+            missionTitle: self.missionTitle,
+            rewardList: self.rewardList,
+            status: self.status,
+            writer: self.writer,
+            image: image,
+            logoImageId: self.imageId ?? "",
+            expireDate: self.expireDate,
+            score: self.score
+        )
     }
 }
 
@@ -50,6 +60,23 @@ struct Reward: Encodable {
 }
 
 typealias PostQuestResponse = ResponseWithoutData
+
+// MARK: - 퀘스트 수정
+struct PutQuestRequest: Encodable {
+    let questId: String
+    let quest: QuestModel
+    
+    struct QuestModel: Encodable {
+        let writer: String
+        let imageId: String
+        let missions: [Mission]
+        let rewards: [Reward]
+        let score: Int
+        let expireDate: String
+    }
+}
+
+typealias PutQuestResponse = ResponseWithoutData
 
 // MARK: - 퀘스트 삭제
 struct DeleteQuestRequest: Encodable {

--- a/MatQ_Admin/Data/Network/API/Target/QuestTarget.swift
+++ b/MatQ_Admin/Data/Network/API/Target/QuestTarget.swift
@@ -11,6 +11,7 @@ import Foundation
 enum QuestTarget {
     case getQuest(GetQuestRequest)
     case postQuest(PostQuestRequest)
+    case putQuest(PutQuestRequest)
     case deleteQuest(DeleteQuestRequest)
 }
 
@@ -19,6 +20,7 @@ extension QuestTarget: TargetType {
         switch self {
         case .getQuest, .postQuest: return URL.makeEndPoint(.admin(endPoint: "quest"))
         case .deleteQuest(let request): return URL.makeEndPoint(.admin(endPoint: "quest/\(request.deleteType.rawValue)"))
+        case .putQuest: return URL.makeEndPoint(.admin(endPoint: "quest/"))
         }
     }
     
@@ -26,6 +28,7 @@ extension QuestTarget: TargetType {
         switch self {
         case .getQuest: return .get
         case .postQuest: return .post
+        case .putQuest: return .put
         case .deleteQuest: return .delete
         }
     }
@@ -34,6 +37,7 @@ extension QuestTarget: TargetType {
         switch self {
         case .getQuest: return nil
         case .postQuest: return nil
+        case .putQuest(let request): return request.questId
         case .deleteQuest: return nil
         }
     }
@@ -42,6 +46,7 @@ extension QuestTarget: TargetType {
         switch self {
         case .getQuest(let request): return .query(request)
         case .postQuest(let request): return .body(request)
+        case .putQuest(let request): return .body(request.quest)
         case .deleteQuest(let request): return .query(request.questId)
         }
     }

--- a/MatQ_Admin/Data/Network/Base/TargetType.swift
+++ b/MatQ_Admin/Data/Network/Base/TargetType.swift
@@ -28,7 +28,7 @@ extension TargetType {
         }
         urlRequest.setValue(HTTPHeaderField.acceptType.value, forHTTPHeaderField: HTTPHeaderField.acceptType.rawValue)
         urlRequest.setValue(HTTPHeaderField.authentication.value, forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
-        if urlRequest.method == .post {
+        if urlRequest.method == .post || urlRequest.method == .put {
             urlRequest.setValue(HTTPHeaderField.contentType.value, forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
         }
         switch parameters {

--- a/MatQ_Admin/Data/Repository/QuestRepository.swift
+++ b/MatQ_Admin/Data/Repository/QuestRepository.swift
@@ -29,6 +29,12 @@ final class QuestRepository: QuestRepositoryInterface {
             .eraseToAnyPublisher()
     }
 
+    func putQuest(request: PutQuestRequest) -> AnyPublisher<Void, NetworkError> {
+        questDataSource.putQuest(request: request)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+    
     func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<Void, NetworkError> {
         questDataSource.deleteQuest(request: request)
             .map { _ in }

--- a/MatQ_Admin/Domain/RepositoryInterface/QuestRepositoryInterface.swift
+++ b/MatQ_Admin/Domain/RepositoryInterface/QuestRepositoryInterface.swift
@@ -10,5 +10,6 @@ import Combine
 protocol QuestRepositoryInterface {
     func getQuestList(request: GetQuestRequest) -> AnyPublisher<[Quest], NetworkError>
     func postQuest(request: PostQuestRequest) -> AnyPublisher<Void, NetworkError>
+    func putQuest(request: PutQuestRequest) -> AnyPublisher<Void, NetworkError>
     func deleteQuest(request: DeleteQuestRequest) -> AnyPublisher<Void, NetworkError>
 }

--- a/MatQ_Admin/Domain/UseCase/PutQuestUseCase.swift
+++ b/MatQ_Admin/Domain/UseCase/PutQuestUseCase.swift
@@ -1,0 +1,105 @@
+//
+//  PutQuestUseCase.swift
+//  MatQ_Admin
+//
+//  Created by Lee Jinhee on 9/24/24.
+//
+
+import Combine
+import UIKit
+
+fileprivate struct QuestRequest {
+    let questId: String
+    let writer: String
+    var imageId: String?
+    let missions: [Mission]
+    let rewards: [Reward]
+    let score: Int
+    let expireDate: String
+    
+    func toPutQuestRequest() -> PutQuestRequest? {
+        guard let imageId = imageId else { return nil }
+        return PutQuestRequest(
+            questId: self.questId,
+            quest: .init(writer: self.writer, imageId: imageId, missions: self.missions, rewards: self.rewards, score: self.score, expireDate: self.expireDate)
+        )
+    }
+}
+
+protocol PutQuestUseCaseInterface {
+    func execute(questId: String, writer: String, image: UIImage, imageId: String, missionTitle: String, rewardList: [Reward], score: Int, expireDate: String, imageUpdated: Bool) -> AnyPublisher<Void, NetworkError>
+}
+
+final class PutQuestUseCase: PutQuestUseCaseInterface {
+    let questRepository: QuestRepositoryInterface
+    let imageRepository: ImageRepositoryInterface
+    
+    init(questRepository: QuestRepositoryInterface, imageRepository: ImageRepositoryInterface) {
+        self.questRepository = questRepository
+        self.imageRepository = imageRepository
+    }
+    
+    func execute(questId: String, writer: String, image: UIImage, imageId: String, missionTitle: String, rewardList: [Reward], score: Int, expireDate: String, imageUpdated: Bool) -> AnyPublisher<Void, NetworkError> {
+        // TODO: PUT이니 수정
+        let request = QuestRequest(questId: questId,
+                                   writer: writer,
+                                   imageId: imageId,
+                                   missions: [.init(content: missionTitle)],
+                                   rewards: rewardList,
+                                   score: score,
+                                   expireDate: expireDate)
+        
+        if imageUpdated {
+            // 새로운 이미지면 퀘스트 생성 TODO: 기존 이미지 삭제 처리or관리
+            return uploadImageAndPutQuest(image: image, request: request)
+        } else {
+            // 기존 이미지면 바로 퀘스트 생성
+            return createQuest(request: request)
+        }
+    }
+    
+    private func uploadImageAndPutQuest(image: UIImage, request: QuestRequest) -> AnyPublisher<Void, NetworkError> {
+        let resizedImage = resizeImageIfNeeded(image)
+        let compressionQualities: [CGFloat] = [0.4, 0.2, 0.05, 0.002]
+        
+        return compressionQualities.publisher
+            .flatMap { quality in
+                self.uploadImage(resizedImage, quality: quality)
+            }
+            .first() // 첫 번째 성공한 이미지만 사용
+            .flatMap { newImageId in
+                var request = request
+                request.imageId = newImageId
+                return self.createQuest(request: request)
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    /// 이미지 사이즈가 큰 경우 리사이즈
+    private func resizeImageIfNeeded(_ image: UIImage) -> UIImage {
+        guard image.size.width > 1500 || image.size.height > 1500 else { return image }
+        print("RESIZE IMAGE \(image.size.width) \(image.size.height)")
+        
+        return image.downSample(scale: 0.5) ?? image
+    }
+    
+    /// 이미지 압축 및 업로드
+    private func uploadImage(_ image: UIImage, quality: CGFloat) -> AnyPublisher<String, NetworkError> {
+        guard let imageData = image.jpegData(compressionQuality: quality) else {
+            return Fail(error: NetworkError.invalidImageData).eraseToAnyPublisher()
+        }
+        
+        let request = PostImageRequest(data: imageData)
+        return imageRepository.postImage(request: request)
+            .mapError { _ in NetworkError.serverError }
+            .eraseToAnyPublisher()
+    }
+    
+    /// 퀘스트 생성 메서드
+    private func createQuest(request: QuestRequest) -> AnyPublisher<Void, NetworkError> {
+        guard let request = request.toPutQuestRequest() else {
+            return Fail(error: NetworkError.invalidImageData).eraseToAnyPublisher()
+        }
+        return questRepository.putQuest(request: request).eraseToAnyPublisher()
+    }
+}

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailView.swift
@@ -39,6 +39,7 @@ struct QuestDetailView: View {
                     .opacity(vm.viewType == .edit ? 1 : 0)
                     .padding(.trailing, 20)
                 }
+            
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     TextFieldComponent(titleName: "미션 제목", contentPlaceholder: vm.items.questTitle, content: $vm.editedItems.questTitle)
@@ -92,12 +93,8 @@ struct QuestDetailView: View {
                     TextFieldComponent(titleName: "작성자", contentPlaceholder: vm.items.writer, content: $vm.editedItems.writer)
                     TextFieldComponent(titleName: "만료 기한", contentPlaceholder: vm.items.expireDate, content: $vm.editedItems.expireDate)
                     
-                    if vm.viewType == .publish {
-                        PhotosPicker(selection: $vm.photosPickerItem, matching: .any(of: [.images, .screenshots])) {
-                            ImageFieldComponent(titleName: "퀘스트 이미지", uiImage: vm.editedItems.questImage)
-                        }
-                    } else {
-                        ImageFieldComponent(titleName: "퀘스트 이미지", uiImage: vm.items.questImage)
+                    PhotosPicker(selection: $vm.photosPickerItem, matching: .any(of: [.images, .screenshots])) {
+                        ImageFieldComponent(titleName: "퀘스트 이미지", uiImage: vm.editedItems.questImage)
                     }
                 }
                 .padding(.horizontal, 20)
@@ -130,18 +127,21 @@ struct QuestDetailView: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            if vm.viewType == .publish {
-                Button {
-                    // TODO: 퀘스트 수정 API 연결
+            // TODO: 스탯 전부 0이면 생성 & 수정 불가
+            Button {
+                if vm.viewType == .edit {
+                    let imageUpdated = vm.editedItems.questImage != vm.items.questImage // 이미지가 변경되었는지 확인
+                    vm.modifyData(vm.editedItems, imageUpdated: imageUpdated)
+                } else if vm.viewType == .publish {
                     vm.createData(data: vm.editedItems)
-                } label: {
-                    Text(vm.viewType.buttonTitle)
                 }
-                .ilsangButtonStyle(type: .primary, isDisabled: vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0) // TODO: 스탯모두 0이면 생성 불가
-                .disabled(vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 8)
+            } label: {
+                Text(vm.viewType.buttonTitle)
             }
+            .ilsangButtonStyle(type: .primary, isDisabled: vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
+            .disabled(vm.editedItems.questTitle.count > 16 || vm.editedItems.questTitle.count == 0)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 8)
         }
     }
 }

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
@@ -72,16 +72,18 @@ final class QuestDetailViewModel: ObservableObject {
         }
     }
 
-    init(viewType: ViewType, questDetail: Quest, postQuestUseCase: PostQuestUseCaseInterface, deleteQuestUseCase: DeleteQuestUseCaseInterface) {
+    init(viewType: ViewType, questDetail: Quest, postQuestUseCase: PostQuestUseCaseInterface, putQuestUseCase: PutQuestUseCaseInterface, deleteQuestUseCase: DeleteQuestUseCaseInterface) {
         self.viewType = viewType
         self.questDetail = questDetail
         self.items = QuestDetailViewModelItem(quest: questDetail)
         self.editedItems = QuestDetailViewModelItem(quest: questDetail)
         self.postQuestUseCase = postQuestUseCase
+        self.putQuestUseCase = putQuestUseCase
         self.deleteQuestUseCase = deleteQuestUseCase
     }
     
     let postQuestUseCase: PostQuestUseCaseInterface
+    let putQuestUseCase: PutQuestUseCaseInterface
     let deleteQuestUseCase: DeleteQuestUseCaseInterface
     
     func createData(data: QuestDetailViewModelItem) {

--- a/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestDetailViewModel.swift
@@ -168,7 +168,7 @@ struct QuestDetailViewModelItem: Equatable {
         self.sociabilityXP = quest.rewardList.first(where: { $0.content == "SOCIABILITY" })?.quantity ?? 0
         self.writer = quest.writer
         self.score = quest.score
-        self.expireDate = quest.expireDate
+        self.expireDate = quest.expireDate.timeAgoSinceDate()
         self.imageId = quest.logoImageId
         self.questImage = quest.image
     }

--- a/MatQ_Admin/Presentation/View/Quest/QuestMainViewModel.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestMainViewModel.swift
@@ -102,7 +102,7 @@ struct QuestMainViewModelItem {
         self.questId = quest.questId
         self.questTitle = quest.missionTitle
         self.logoImageId = quest.logoImageId
-        self.expireDate = quest.expireDate
+        self.expireDate = quest.expireDate.timeAgoSinceDate()
         self.logoImage = quest.image
         self.status = quest.status
     }


### PR DESCRIPTION
close #91 

### 퀘스트 수정(PUT) API 연결 중 에러 발생
`ErrorResponse(errMessage: "Content-Type \'application/octet-stream\' is not supported", status: "INTERNAL_SERVER_ERROR", message: "An unknown error occurred.") `


1) 기존에 POST만 대응해서 헤더넣는 코드 짰었던게 기억나서 찾아봤으나 안보이기도 하고, 
2) 너무 처음보는 에러여서 검색해봤는데, 스웨거 관련된 글들이 많았었으음... (백엔드에서 설정을 다르게 해둔건가 싶어 최후의 수단으로 결정,,)
3) Body값을 이상하게 보내고 있나 확인했는데 그것도 아니었음,,
4) 다시 보니 ㅎㅎ; 처음에 생각했던 post만 대응해서 헤더 넣는 부분이 있어서 put 메서드도 헤더 넣도록 대응해줘서 해결

```swift
if urlRequest.method == .post || urlRequest.method == .put {
    urlRequest.setValue(HTTPHeaderField.contentType.value, forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
}
```