### PR TITLE
[Bug/#99] 이미지 없으면 수정안되는 현상 해결 (기본 이미지 아이디값 수정)

### DIFF
--- a/MatQ_Admin.xcodeproj/project.pbxproj
+++ b/MatQ_Admin.xcodeproj/project.pbxproj
@@ -946,7 +946,7 @@
 				CODE_SIGN_ENTITLEMENTS = MatQ_Admin/MatQ_Admin.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"MatQ_Admin/Resources/Preview Content\"";
 				DEVELOPMENT_TEAM = VJUK3HBJ2M;
 				ENABLE_PREVIEWS = YES;
@@ -967,7 +967,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamfair.MatQ-Admin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -991,7 +991,7 @@
 				CODE_SIGN_ENTITLEMENTS = MatQ_Admin/MatQ_Admin.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"MatQ_Admin/Resources/Preview Content\"";
 				DEVELOPMENT_TEAM = VJUK3HBJ2M;
 				ENABLE_PREVIEWS = YES;
@@ -1011,7 +1011,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.teamfair.MatQ-Admin";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MatQ_Admin/Domain/Entity/Quest.swift
+++ b/MatQ_Admin/Domain/Entity/Quest.swift
@@ -45,5 +45,5 @@ struct Quest {
     static let initialData = Quest.init()
     static let mockData1 = Quest.init(questId: UUID().uuidString, missionTitle: "밥먹기", rewardList: [], status: "", writer: "이기욱", image: nil, logoImageId: "", expireDate: "2024-12-31", score: 0)
     static let mockData2 = Quest.init(questId: UUID().uuidString, missionTitle: "커피 마시기", rewardList: [], status: "", writer: "이기욱", image: nil, logoImageId: "", expireDate: "2024-12-31", score: 0)
-    static let defaultLogoImageId = "IMMA2024072114492808"
+    static let defaultLogoImageId = "IMQU2024092917552786"
 }

--- a/MatQ_Admin/Presentation/View/Quest/QuestItemView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestItemView.swift
@@ -8,17 +8,26 @@
 import SwiftUI
 
 struct QuestItemView: View {
-    let questImage : UIImage
+    let questImage : UIImage?
     let missionTitle : String
     let expireDate : String
 
     var body: some View {
         HStack(spacing: 0){
-            Image(uiImage: questImage)
-                .resizable()
-                .frame(width: UIImageSize.small.value, height: UIImageSize.small.value)
-                .cornerRadius(10)
-                .padding(.trailing, 14)
+            Group {
+                if let questImage = questImage {
+                    Image(uiImage: questImage)
+                        .resizable()
+                        .frame(width: UIImageSize.small.value, height: UIImageSize.small.value)
+                } else {
+                    Rectangle()
+                        .frame(width: UIImageSize.small.value, height: UIImageSize.small.value)
+                        .foregroundStyle(.gray100)
+                }
+            }
+            .cornerRadius(10)
+            .padding(.trailing, 14)
+            
             VStack(alignment: .leading, spacing: 8) {
                 Text(missionTitle)
                     .font(.system(size: 15, weight: .bold))

--- a/MatQ_Admin/Presentation/View/Quest/QuestMainView.swift
+++ b/MatQ_Admin/Presentation/View/Quest/QuestMainView.swift
@@ -94,7 +94,7 @@ struct QuestMainView: View {
                         )
                     )
                 } label: {
-                    QuestItemView(questImage: item.logoImage ?? .nullimage, missionTitle: item.questTitle, expireDate: item.expireDate)
+                    QuestItemView(questImage: item.logoImage, missionTitle: item.questTitle, expireDate: item.expireDate)
                         .opacity(item.status == "DELETED" ? 0.3 : 1)
                 }
             }


### PR DESCRIPTION
- 기존에 imageId가 서버에 없는 이미지여서 새로 등록한 이미지로 수정